### PR TITLE
refactor: enable disable ecosystem: 107

### DIFF
--- a/libs/prisma-service/prisma/data/credebl-master-table.json
+++ b/libs/prisma-service/prisma/data/credebl-master-table.json
@@ -55,6 +55,21 @@
       "description": "Joins the organization as member"
     }
   ],
+  "ecosystemRoleData": [
+    {
+      "name": "Ecosystem Owner",
+      "description": "Ecosystem Owner"
+    },
+    {
+      "name": "Ecosystem Lead",
+      "description": "Ecosystem Lead"
+    },
+    {
+      "name": "Ecosystem Member",
+      "description": "Ecosystem Member"
+    }
+  ],
+
   "agentTypeData": [
     {
       "agent": "AFJ"

--- a/libs/prisma-service/prisma/migrations/20231003080927_ecosystem_flag/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20231003080927_ecosystem_flag/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - The primary key for the `ecosystem_roles` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ecosystem_orgs" DROP CONSTRAINT "ecosystem_orgs_ecosystemRoleId_fkey";
+
+-- AlterTable
+ALTER TABLE "ecosystem_orgs" ALTER COLUMN "ecosystemRoleId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "ecosystem_roles" DROP CONSTRAINT "ecosystem_roles_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "ecosystem_roles_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "ecosystem_roles_id_seq";
+
+-- AlterTable
+ALTER TABLE "platform_config" ADD COLUMN     "enableEcosystem" BOOLEAN NOT NULL DEFAULT false;
+
+-- AddForeignKey
+ALTER TABLE "ecosystem_orgs" ADD CONSTRAINT "ecosystem_orgs_ecosystemRoleId_fkey" FOREIGN KEY ("ecosystemRoleId") REFERENCES "ecosystem_roles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/libs/prisma-service/prisma/migrations/20231003114625_ecosystem_logo/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20231003114625_ecosystem_logo/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ecosystem" ADD COLUMN     "logoUrl" TEXT;

--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -132,6 +132,7 @@ model platform_config {
   emailFrom           String    @db.VarChar
   apiEndpoint         String    @db.VarChar
   tailsFileServer     String    @db.VarChar
+  enableEcosystem     Boolean   @default(false)
   createDateTime      DateTime  @default(now()) @db.Timestamptz(6)
   createdBy           Int       @default(1)
   lastChangedDateTime DateTime  @default(now()) @db.Timestamptz(6)
@@ -309,7 +310,7 @@ model presentations {
 }
 
 model ecosystem_roles {
-  id                  Int              @id @default(autoincrement())
+  id                  String           @id @default(uuid())
   name                String           @unique
   description         String
   ecosystemOrgs       ecosystem_orgs[]
@@ -324,6 +325,7 @@ model ecosystem {
   id                      String           @id @default(uuid())
   name                    String
   description             String
+  logoUrl                 String?
   tags                    String
   ecosystemOrgs           ecosystem_orgs[]
   ecosystemUsers          ecosystem_users[]
@@ -363,11 +365,11 @@ model ecosystem_users {
 }
 
 model ecosystem_orgs {
-  id                  String           @id @default(uuid()) // auto-increment
+  id                  String           @id @default(uuid())
   orgId               String
   status              String
   ecosystemId         String
-  ecosystemRoleId     Int
+  ecosystemRoleId     String
   ecosystem           ecosystem        @relation(fields: [ecosystemId], references: [id])
   ecosystemRole       ecosystem_roles  @relation(fields: [ecosystemRoleId], references: [id])
   createDateTime      DateTime         @default(now()) @db.Timestamptz(6)

--- a/libs/prisma-service/prisma/seed.ts
+++ b/libs/prisma-service/prisma/seed.ts
@@ -113,6 +113,19 @@ const createLedger = async (): Promise<void> => {
     }
 };
 
+const createEcosystemRoles = async (): Promise<void> => {
+    try {
+        const { ecosystemRoleData } = JSON.parse(configData);
+        const ecosystemRoles = await prisma.ecosystem_roles.createMany({
+            data: ecosystemRoleData
+        });
+
+        logger.log(ecosystemRoles);
+    } catch (e) {
+        logger.error('An error occurred seeding ecosystemRoles:', e);
+    }
+};
+
 async function main(): Promise<void> {
 
     await createPlatformConfig();
@@ -123,6 +136,7 @@ async function main(): Promise<void> {
     await createPlatformUserOrgRoles();
     await createOrgAgentTypes();
     await createLedger();
+    await createEcosystemRoles();
 }
 
 


### PR DESCRIPTION
- Implemented enable ecosystem flag in the platform config.
- Included master entries for ecosystem roles in the prisma seed.
- Included `logoUrl` in the ecosystem model of schema prisma.