### PR TITLE
fix: handled empty resourceId for ecosystem's schema list

### DIFF
--- a/apps/ecosystem/src/ecosystem.repository.ts
+++ b/apps/ecosystem/src/ecosystem.repository.ts
@@ -595,13 +595,16 @@ export class EcosystemRepository {
             ecosystem: {
               id: ecosystemId
             }
+          },
+          resourceId: {
+            not: {
+              equals: null
+            }
           }
         }
       });
-
       const schemaArray = [];
       schemaDetails.map((schemaData) => schemaArray.push(schemaData.resourceId));
-
       const schemasResult = await this.prisma.schema.findMany({
         where: {
           OR: [


### PR DESCRIPTION
### What ###
- Fixed empty resourceId issue for the ecosystem's schema list