### PR TITLE
fix: connection pool of prisma postgres

### DIFF
--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -4,7 +4,8 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url      = env("POOL_DATABASE_URL")
+  directUrl = env("DATABASE_URL")
 }
 
 model user {


### PR DESCRIPTION
## What ##
-  Included pool database URL in schema prisma

## Why ##
- To use the connection pooling for postgres DB.