### PR TITLE
refactor: bulk issuance file data model 

### DIFF
--- a/libs/prisma-service/prisma/migrations/20231116112146_status_file_data/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20231116112146_status_file_data/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "file_data" ADD COLUMN     "credDefId" TEXT,
+ADD COLUMN     "schemaId" TEXT,
+ADD COLUMN     "status" BOOLEAN NOT NULL DEFAULT false;

--- a/libs/prisma-service/prisma/migrations/20231116114452_credentials_file_data/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20231116114452_credentials_file_data/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "file_data" ADD COLUMN     "credential_data" JSONB;

--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -442,4 +442,8 @@ model file_data {
   deletedAt           DateTime?   @db.Timestamp(6)
   fileUploadId        String
   fileUpload          file_upload @relation(fields: [fileUploadId], references: [id])
+  schemaId            String?
+  credDefId           String?
+  status              Boolean           @default(false)
+
 }

--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -445,5 +445,5 @@ model file_data {
   schemaId            String?
   credDefId           String?
   status              Boolean           @default(false)
-
+  credential_data     Json?
 }


### PR DESCRIPTION
## What ##
-  Included `status`,  `schemaId` and `credDefId` in the `file_data` model

## Why ##
- To bulk issue the credentials for user.