### PR TITLE
refactor: retrieve list of all schemas by network

### DIFF
--- a/apps/api-gateway/src/interfaces/ISchemaSearch.interface.ts
+++ b/apps/api-gateway/src/interfaces/ISchemaSearch.interface.ts
@@ -1,6 +1,7 @@
 import { IUserRequestInterface } from '../schema/interfaces';
 
 export interface ISchemaSearchInterface {
+    ledgerId?: string;
     pageNumber: number;
     pageSize: number;
     sorting: string;

--- a/apps/api-gateway/src/platform/platform.controller.ts
+++ b/apps/api-gateway/src/platform/platform.controller.ts
@@ -33,8 +33,9 @@ export class PlatformController {
         @Res() res: Response,
         @User() user: IUserRequestInterface
     ): Promise<object> {
-        const { pageSize, searchByText, pageNumber, sorting, sortByValue } = getAllSchemaDto;
+        const { ledgerId, pageSize, searchByText, pageNumber, sorting, sortByValue } = getAllSchemaDto;
         const schemaSearchCriteria: ISchemaSearchInterface = {
+            ledgerId,
             pageNumber,
             searchByText,
             pageSize,
@@ -42,7 +43,6 @@ export class PlatformController {
             sortByValue
         };
         const schemasResponse = await this.platformService.getAllSchema(schemaSearchCriteria, user);
-
         const finalResponse: IResponseType = {
             statusCode: HttpStatus.OK,
             message: ResponseMessages.schema.success.fetch,

--- a/apps/api-gateway/src/schema/dtos/get-all-schema.dto.ts
+++ b/apps/api-gateway/src/schema/dtos/get-all-schema.dto.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-inferrable-types */
 /* eslint-disable camelcase */
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SortValue } from '../../enum';
 import { Type } from 'class-transformer';
 import { IsOptional } from 'class-validator';
@@ -49,6 +49,11 @@ export class GetCredentialDefinitionBySchemaIdDto {
 }
 
 export class GetAllSchemaByPlatformDto {
+
+    @ApiPropertyOptional()
+    @IsOptional()
+    ledgerId?: string;
+    
     @ApiProperty({ required: false })
     @IsOptional()
     pageNumber: number = 1;

--- a/apps/api-gateway/src/schema/dtos/get-all-schema.dto.ts
+++ b/apps/api-gateway/src/schema/dtos/get-all-schema.dto.ts
@@ -50,6 +50,7 @@ export class GetCredentialDefinitionBySchemaIdDto {
 
 export class GetAllSchemaByPlatformDto {
 
+    @ApiProperty()
     @ApiPropertyOptional()
     @IsOptional()
     ledgerId?: string;

--- a/apps/ledger/src/schema/interfaces/schema-payload.interface.ts
+++ b/apps/ledger/src/schema/interfaces/schema-payload.interface.ts
@@ -48,6 +48,7 @@ export interface ISchemaSearchInterface {
 }
 
 export interface ISchemaSearchCriteria {
+    ledgerId?: string;
     pageNumber: number;
     pageSize: number;
     sorting: string;

--- a/apps/ledger/src/schema/repositories/schema.repository.ts
+++ b/apps/ledger/src/schema/repositories/schema.repository.ts
@@ -202,7 +202,7 @@ export class SchemaRepository {
       throw error;
     }
   }
-
+ 
   async getAllSchemaDetails(payload: ISchemaSearchCriteria): Promise<{
     schemasCount: number;
     schemasResult: {
@@ -216,10 +216,11 @@ export class SchemaRepository {
       issuerId: string;
       orgId: string;
     }[];
-  }> {
+  }> { 
     try {
       const schemasResult = await this.prisma.schema.findMany({
         where: {
+          ledgerId: payload.ledgerId,
           OR: [
             { name: { contains: payload.searchByText, mode: 'insensitive' } },
             { version: { contains: payload.searchByText, mode: 'insensitive' } },
@@ -245,7 +246,11 @@ export class SchemaRepository {
         skip: (payload.pageNumber - 1) * payload.pageSize
       });
 
-      const schemasCount = await this.prisma.schema.count();
+      const schemasCount = await this.prisma.schema.count({
+        where: {
+          ledgerId: payload.ledgerId
+        }
+      });
       return { schemasCount, schemasResult };
     } catch (error) {
       this.logger.error(`Error in getting schemas: ${error}`);


### PR DESCRIPTION
## What ##
- Implement a function to retrieve a list of all schemas by network.

## Why ##
- To retrieve a list of all schemas by network is essential for seamless credential definition creation. 
- By having a comprehensive list of schemas available within the selected network, potential issues related to mismatched or unavailable schemas can be preemptively addressed. 
- This ensures that cred-def creation is accurate, preventing problems that may arise from incompatible schema information during the credential definition process.