### PR TITLE
fix: create service name random in shell script

### DIFF
--- a/Dockerfiles/Dockerfile.agnet-provisioning
+++ b/Dockerfiles/Dockerfile.agnet-provisioning
@@ -1,11 +1,15 @@
 # Stage 1: Build the application
 FROM node:18-alpine as build
-RUN npm install -g pnpm
+# RUN npm install -g pnpm
 # Install AWS CLI
-RUN apk update
-RUN apk add openssh-client
-RUN apk update
-RUN apk add aws-cli
+# RUN apk update
+# RUN apk add openssh-client
+# RUN apk update
+# RUN apk add aws-cli
+RUN npm install -g pnpm \
+    && apk update \
+    && apk add openssh-client \
+    && apk add aws-cli
 
 # Set the working directory
 WORKDIR /app
@@ -29,10 +33,14 @@ RUN pnpm run build agent-provisioning
 # Stage 2: Create the final image
 FROM node:18-alpine as prod
 # Install AWS CLI
-RUN apk update
-RUN apk add openssh-client
-RUN apk update
-RUN apk add aws-cli
+# RUN apk update
+# RUN apk add openssh-client
+# RUN apk update
+# RUN apk add aws-cli
+RUN npm install -g pnpm \
+    && apk update \
+    && apk add openssh-client \
+    && apk add aws-cli
 
 WORKDIR /app
 RUN npm install -g pnpm

--- a/Dockerfiles/Dockerfile.agnet-provisioning
+++ b/Dockerfiles/Dockerfile.agnet-provisioning
@@ -1,6 +1,11 @@
 # Stage 1: Build the application
 FROM node:18-alpine as build
 RUN npm install -g pnpm
+# Install AWS CLI
+RUN apk update
+RUN apk add openssh-client
+RUN apk update
+RUN apk add aws-cli
 
 # Set the working directory
 WORKDIR /app
@@ -23,6 +28,12 @@ RUN pnpm run build agent-provisioning
 
 # Stage 2: Create the final image
 FROM node:18-alpine as prod
+# Install AWS CLI
+RUN apk update
+RUN apk add openssh-client
+RUN apk update
+RUN apk add aws-cli
+
 WORKDIR /app
 RUN npm install -g pnpm
 

--- a/apps/agent-provisioning/AFJ/scripts/start_agent_ecs.sh
+++ b/apps/agent-provisioning/AFJ/scripts/start_agent_ecs.sh
@@ -24,6 +24,18 @@ CLUSTER_NAME=${19}
 TESKDEFINITION_FAMILY=${20}
 
 DESIRED_COUNT=1
+
+generate_random_string() {
+  echo "$(date +%s%N | sha256sum | base64 | head -c 12)"
+}
+
+# Call the function to generate a random string
+random_string=$(generate_random_string)
+
+# Print the generated random string
+echo "Random String: $random_string"
+
+SERVICE_NAME="${AGENCY}-${CONTAINER_NAME}-service-${random_string}"
 EXTERNAL_IP=$(echo "$2" | tr -d '[:space:]')
 ADMIN_PORT_FILE="$PWD/agent-provisioning/AFJ/port-file/last-admin-port.txt"
 INBOUND_PORT_FILE="$PWD/agent-provisioning/AFJ/port-file/last-inbound-port.txt"
@@ -73,7 +85,6 @@ last_used_inbound_port=$(increment_port "$last_used_inbound_port" "$last_used_in
 echo "$last_used_inbound_port" > "$INBOUND_PORT_FILE"
 INBOUND_PORT="$last_used_inbound_port"
 
-SERVICE_NAME="${AGENCY}-${CONTAINER_NAME}-service-${ADMIN_PORT}"
 echo "Last used admin port: $ADMIN_PORT"
 echo "Last used inbound port: $INBOUND_PORT"
 echo "AGENT SPIN-UP STARTED"
@@ -242,7 +253,7 @@ EOF
 
   cat <<EOF >${PWD}/agent-provisioning/AFJ/token/${AGENCY}_${CONTAINER_NAME}.json
     {
-        "token" : "$token"
+        "token" : ""
     }
 EOF
 

--- a/apps/agent-provisioning/src/agent-provisioning.service.ts
+++ b/apps/agent-provisioning/src/agent-provisioning.service.ts
@@ -22,10 +22,10 @@ export class AgentProvisioningService {
   async walletProvision(payload: IWalletProvision): Promise<object> {
     try {
 
-      const { containerName, externalIp, orgId, seed, walletName, walletPassword, walletStorageHost, walletStoragePassword, walletStoragePort, walletStorageUser, webhookEndpoint, agentType, protocol, afjVersion, tenant, indyLedger, apiKey } = payload;
+      const { containerName, externalIp, orgId, seed, walletName, walletPassword, walletStorageHost, walletStoragePassword, walletStoragePort, walletStorageUser, webhookEndpoint, agentType, protocol, afjVersion, tenant, indyLedger } = payload;
       if (agentType === AgentType.AFJ) {
         // The wallet provision command is used to invoke a shell script
-        const walletProvision = `${process.cwd() + process.env.AFJ_AGENT_SPIN_UP} ${orgId} "${externalIp}" "${walletName}" "${walletPassword}" ${seed} ${webhookEndpoint} ${walletStorageHost} ${walletStoragePort} ${walletStorageUser} ${walletStoragePassword} ${containerName} ${protocol} ${tenant} ${afjVersion} ${indyLedger} ${apiKey} ${process.env.AGENT_HOST} ${process.env.AWS_ACCOUNT_ID} ${process.env.S3_BUCKET_ARN} ${process.env.CLUSTER_NAME} ${process.env.TESKDEFINITION_FAMILY}`;
+        const walletProvision = `${process.cwd() + process.env.AFJ_AGENT_SPIN_UP} ${orgId} "${externalIp}" "${walletName}" "${walletPassword}" ${seed} ${webhookEndpoint} ${walletStorageHost} ${walletStoragePort} ${walletStorageUser} ${walletStoragePassword} ${containerName} ${protocol} ${tenant} ${afjVersion} ${indyLedger} ${process.env.AGENT_HOST} ${process.env.AWS_ACCOUNT_ID} ${process.env.S3_BUCKET_ARN} ${process.env.CLUSTER_NAME} ${process.env.TESKDEFINITION_FAMILY}`;
         const spinUpResponse: object = new Promise(async (resolve) => {
 
           await exec(walletProvision, async (err, stdout, stderr) => {


### PR DESCRIPTION
### What ###
Create a random service name within the shell script. It eliminates unnecessary parameters related to agent provisioning.

### Why ###
The current script includes unceremonious parameters and agent-provisioning, which are redundant and can lead to issues. This fix aims to streamline the script by removing these unnecessary elements.

### How ###
Script to generate a random service name without the need for explicit parameters and eliminating the agent-provisioning code. The updated script is designed to improve simplicity and efficiency.