### PR TITLE
fix: solved the agent spin-up with apiKey updation on org_agent table

### DIFF
--- a/apps/agent-provisioning/AFJ/scripts/start_agent.sh
+++ b/apps/agent-provisioning/AFJ/scripts/start_agent.sh
@@ -23,6 +23,7 @@ INBOUND_PORT_FILE="$PWD/apps/agent-provisioning/AFJ/port-file/last-inbound-port.
 ADMIN_PORT=8001
 INBOUND_PORT=9001
 
+
 increment_port() {
     local port="$1"
     local lower_limit="$2"
@@ -96,7 +97,7 @@ if [ -f "$CONFIG_FILE" ]; then
   rm "$CONFIG_FILE"
 fi
 
-cat <<EOF >>${CONFIG_FILE}
+cat <<EOF >${CONFIG_FILE}
 {
   "label": "${AGENCY}_${CONTAINER_NAME}",
   "walletId": "$WALLET_NAME",
@@ -140,7 +141,7 @@ if [ -f "$DOCKER_COMPOSE" ]; then
   # If it exists, remove the file
   rm "$DOCKER_COMPOSE"
 fi
-cat <<EOF >>${DOCKER_COMPOSE}
+cat <<EOF >${DOCKER_COMPOSE}
 version: '3'
 
 services:
@@ -216,13 +217,13 @@ if [ $? -eq 0 ]; then
     # If it exists, remove the file
     rm "$ENDPOINT"
     fi
-    cat <<EOF >>${ENDPOINT}
+    cat <<EOF >${ENDPOINT}
     {
         "CONTROLLER_ENDPOINT":"${EXTERNAL_IP}:${ADMIN_PORT}"
     }
 EOF
 
-    cat <<EOF >>${PWD}/token/${AGENCY}_${CONTAINER_NAME}.json
+    cat <<EOF >${PWD}/token/${AGENCY}_${CONTAINER_NAME}.json
     {
         "token" : "$token"
     }

--- a/apps/agent-provisioning/src/agent-provisioning.service.ts
+++ b/apps/agent-provisioning/src/agent-provisioning.service.ts
@@ -25,7 +25,7 @@ export class AgentProvisioningService {
       const { containerName, externalIp, orgId, seed, walletName, walletPassword, walletStorageHost, walletStoragePassword, walletStoragePort, walletStorageUser, webhookEndpoint, agentType, protocol, afjVersion, tenant, indyLedger } = payload;
       if (agentType === AgentType.AFJ) {
         // The wallet provision command is used to invoke a shell script
-        const walletProvision = `${process.cwd() + process.env.AFJ_AGENT_SPIN_UP} ${orgId} "${externalIp}" "${walletName}" "${walletPassword}" ${seed} ${webhookEndpoint} ${walletStorageHost} ${walletStoragePort} ${walletStorageUser} ${walletStoragePassword} ${containerName} ${protocol} ${tenant} ${afjVersion} ${indyLedger} ${process.env.AGENT_HOST} ${process.env.AWS_ACCOUNT_ID} ${process.env.S3_BUCKET_ARN} ${process.env.CLUSTER_NAME} ${process.env.TESKDEFINITION_FAMILY}`;
+        const walletProvision = `${process.cwd() + process.env.AFJ_AGENT_SPIN_UP} ${orgId} "${externalIp}" "${walletName}" "${walletPassword}" ${seed} ${webhookEndpoint} ${walletStorageHost} ${walletStoragePort} ${walletStorageUser} ${walletStoragePassword} ${containerName} ${protocol} ${tenant} ${afjVersion} "${indyLedger}" ${process.env.AGENT_HOST} ${process.env.AWS_ACCOUNT_ID} ${process.env.S3_BUCKET_ARN} ${process.env.CLUSTER_NAME} ${process.env.TESKDEFINITION_FAMILY}`;
         const spinUpResponse: object = new Promise(async (resolve) => {
 
           await exec(walletProvision, async (err, stdout, stderr) => {

--- a/apps/agent-service/src/repositories/agent-service.repository.ts
+++ b/apps/agent-service/src/repositories/agent-service.repository.ts
@@ -132,7 +132,8 @@ export class AgentServiceRepository {
                     agentId: storeOrgAgentDetails.agentId ? storeOrgAgentDetails.agentId : null,
                     orgAgentTypeId: storeOrgAgentDetails.orgAgentTypeId ? storeOrgAgentDetails.orgAgentTypeId : null,
                     tenantId: storeOrgAgentDetails.tenantId ? storeOrgAgentDetails.tenantId : null,
-                    ledgerId: storeOrgAgentDetails.ledgerId[0]
+                    ledgerId: storeOrgAgentDetails.ledgerId[0],
+                    apiKey: storeOrgAgentDetails.apiKey
                 },
                 select: {
                     id: true

--- a/apps/connection/src/connection.service.ts
+++ b/apps/connection/src/connection.service.ts
@@ -37,7 +37,7 @@ export class ConnectionService {
    */
   async createLegacyConnectionInvitation(payload: IConnection): Promise<ICreateConnectionUrl> {
 
-    const {orgId, multiUseInvitation, autoAcceptConnection, alias, label} = payload;
+    const { orgId, multiUseInvitation, autoAcceptConnection, alias, label } = payload;
     try {
       const connectionInvitationExist = await this.connectionRepository.getConnectionInvitationByOrgId(orgId);
       if (connectionInvitationExist) {
@@ -69,12 +69,12 @@ export class ConnectionService {
 
       // const apiKey = platformConfig?.sgApiKey;
 
-      const apiKey = await this._getOrgAgentApiKey(orgId);
-      // let apiKey:string = await this.cacheService.get(CommonConstants.CACHE_APIKEY_KEY);
-      // this.logger.log(`cachedApiKey----getConnections,${apiKey}`);
-      //if(!apiKey || apiKey === null || apiKey === undefined) {
-      //  apiKey = await this._getOrgAgentApiKey(orgId);
-      // }
+      // const api"Key = await this._getOrgAgentApiKey(orgId);
+      let apiKey: string = await this.cacheService.get(CommonConstants.CACHE_APIKEY_KEY);
+      this.logger.log(`cachedApiKey----getConnections,${apiKey}`);
+      if (!apiKey || null === apiKey || apiKey === undefined) {
+        apiKey = await this._getOrgAgentApiKey(orgId);
+      }
       const createConnectionInvitation = await this._createConnectionInvitation(connectionPayload, url, apiKey);
       const invitationObject = createConnectionInvitation?.message?.invitation['@id'];
       let shortenedUrl;
@@ -223,15 +223,15 @@ export class ConnectionService {
         lastPage: Math.ceil(getConnectionList.connectionCount / connectionSearchCriteria.pageSize),
         data: getConnectionList.connectionsList
       };
-        return connectionResponse;
+      return connectionResponse;
     } catch (error) {
 
       this.logger.error(
         `[getConnections] [NATS call]- error in fetch connections details : ${JSON.stringify(error)}`
       );
 
-      throw new RpcException(error.response ? error.response : error);      
-    } 
+      throw new RpcException(error.response ? error.response : error);
+    }
   }
 
   async _getAllConnections(
@@ -293,19 +293,19 @@ export class ConnectionService {
 
 
       // const apiKey = await this._getOrgAgentApiKey(orgId);
-      let apiKey:string = await this.cacheService.get(CommonConstants.CACHE_APIKEY_KEY);
+      let apiKey: string = await this.cacheService.get(CommonConstants.CACHE_APIKEY_KEY);
       this.logger.log(`cachedApiKey----getConnectionsById,${apiKey}`);
-     if (!apiKey || null === apiKey  ||  undefined === apiKey) {
-       apiKey = await this._getOrgAgentApiKey(orgId);
+      if (!apiKey || null === apiKey || undefined === apiKey) {
+        apiKey = await this._getOrgAgentApiKey(orgId);
       }
       const createConnectionInvitation = await this._getConnectionsByConnectionId(url, apiKey);
       return createConnectionInvitation;
-     
+
 
     } catch (error) {
       this.logger.error(`[getConnectionsById] - error in get connections : ${JSON.stringify(error)}`);
 
-      if (error?.response?.error?.reason)  {
+      if (error?.response?.error?.reason) {
         throw new RpcException({
           message: ResponseMessages.connection.error.connectionNotFound,
           statusCode: error?.response?.status,
@@ -322,25 +322,25 @@ export class ConnectionService {
     apiKey: string
   ): Promise<IConnectionDetailsById> {
 
-      //nats call in agent service for fetch connection details
-      const pattern = { cmd: 'agent-get-connection-details-by-connectionId' };
-      const payload = { url, apiKey };
-      return this.connectionServiceProxy
-        .send<IConnectionDetailsById>(pattern, payload)
-        .toPromise()
-        .catch(error => {
-          this.logger.error(
-                `[_getConnectionsByConnectionId] [NATS call]- error in fetch connections : ${JSON.stringify(error)}`
-              );         
-            throw new HttpException(
-            {
-              status: error.statusCode,  
-              error: error.error?.message?.error ? error.error?.message?.error : error.error,
-              message: error.message
-            }, error.error);
-        });
+    //nats call in agent service for fetch connection details
+    const pattern = { cmd: 'agent-get-connection-details-by-connectionId' };
+    const payload = { url, apiKey };
+    return this.connectionServiceProxy
+      .send<IConnectionDetailsById>(pattern, payload)
+      .toPromise()
+      .catch(error => {
+        this.logger.error(
+          `[_getConnectionsByConnectionId] [NATS call]- error in fetch connections : ${JSON.stringify(error)}`
+        );
+        throw new HttpException(
+          {
+            status: error.statusCode,
+            error: error.error?.message?.error ? error.error?.message?.error : error.error,
+            message: error.message
+          }, error.error);
+      });
   }
-  
+
   /**
    * Description: Fetch agent url
    * @param referenceId

--- a/apps/connection/src/connection.service.ts
+++ b/apps/connection/src/connection.service.ts
@@ -67,12 +67,9 @@ export class ConnectionService {
       const orgAgentType = await this.connectionRepository.getOrgAgentType(agentDetails?.orgAgentTypeId);
       const url = await this.getAgentUrl(orgAgentType, agentEndPoint, agentDetails?.tenantId);
 
-      // const apiKey = platformConfig?.sgApiKey;
-
-      // const api"Key = await this._getOrgAgentApiKey(orgId);
       let apiKey: string = await this.cacheService.get(CommonConstants.CACHE_APIKEY_KEY);
       this.logger.log(`cachedApiKey----getConnections,${apiKey}`);
-      if (!apiKey || null === apiKey || apiKey === undefined) {
+      if (!apiKey || null === apiKey || undefined === apiKey) {
         apiKey = await this._getOrgAgentApiKey(orgId);
       }
       const createConnectionInvitation = await this._createConnectionInvitation(connectionPayload, url, apiKey);


### PR DESCRIPTION
### What ###
Resolves the agent spin-up issue by implementing a crucial apiKey update in the org_agent table.

### Why ###
The agent spin-up problem was identified to be linked to outdated API keys stored in the org_agent table. This update aims to ensure that the API keys are consistently updated, thus eliminating the spin-up issue.

### How ###
The update involves making necessary modifications to the org_agent table, ensuring that the apiKey field is updated appropriately during the agent spin-up process. This will result in improved functionality and a more reliable agent deployment process.