### PR TITLE
refactor: organization profile APIs

### DIFF
--- a/apps/api-gateway/src/authz/guards/org-roles.guard.ts
+++ b/apps/api-gateway/src/authz/guards/org-roles.guard.ts
@@ -1,4 +1,4 @@
-import { CanActivate, ExecutionContext, ForbiddenException, Logger } from '@nestjs/common';
+import { BadRequestException, CanActivate, ExecutionContext, ForbiddenException, Logger } from '@nestjs/common';
 
 import { HttpException } from '@nestjs/common';
 import { HttpStatus } from '@nestjs/common';
@@ -27,17 +27,24 @@ export class OrgRolesGuard implements CanActivate {
 
     // Request requires org check, proceed with it
     const req = context.switchToHttp().getRequest();
-
     const { user } = req;
+  
+    req.params.orgId = req.params?.orgId ? req.params?.orgId?.trim() : '';
+    req.query.orgId = req.query?.orgId ? req.query?.orgId?.trim() : '';
+    req.body.orgId = req.body?.orgId ? req.body?.orgId?.trim() : '';
 
-    if (req.params.orgId || req.query.orgId || req.body.orgId) {
-      const orgId = req.params.orgId || req.query.orgId || req.body.orgId;
+    const orgId = req.params.orgId || req.query.orgId || req.body.orgId;
+  
+    if (!orgId) {
+      throw new BadRequestException(ResponseMessages.organisation.error.orgIdIsRequired);
+    }
 
+    if (orgId) {     
       const specificOrg = user.userOrgRoles.find((orgDetails) => {
         if (!orgDetails.orgId) {
           return false;
         }
-        return orgDetails.orgId.toString() === orgId.toString();
+        return orgDetails.orgId.toString().trim() === orgId.toString().trim();
       });
 
       if (!specificOrg) {
@@ -47,7 +54,7 @@ export class OrgRolesGuard implements CanActivate {
       user.selectedOrg = specificOrg;
       // eslint-disable-next-line array-callback-return
       user.selectedOrg.orgRoles = user.userOrgRoles.map((orgRoleItem) => {
-        if (orgRoleItem.orgId && orgRoleItem.orgId.toString() === orgId.toString()) {
+        if (orgRoleItem.orgId && orgRoleItem.orgId.toString().trim() === orgId.toString().trim()) {
           return orgRoleItem.orgRole.name;
         }
       });

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -46,7 +46,9 @@ export class OrganizationController {
   @Get('/profile/:orgId')
   @ApiOperation({ summary: 'Organization Profile', description: 'Get organization profile details' })
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
-  async getOrgPofile(@Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, @Res() res: Response): Promise<Response> {
+  async getOrgPofile(@Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }}))
+  orgId: string, @Res() res: Response): Promise<Response> {
+
     const orgProfile = await this.organizationService.getOrgPofile(orgId);
 
     const base64Data = orgProfile['logoUrl'];
@@ -149,10 +151,10 @@ export class OrganizationController {
   @Get('/dashboard/:orgId')
   @ApiOperation({ summary: 'Get dashboard details', description: 'Get organization dashboard details' })
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   @ApiBearerAuth()
-
-  async getOrganizationDashboard(@Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, @Res() res: Response, @User() reqUser: user): Promise<Response> {
+  @Roles(OrgRoles.OWNER, OrgRoles.SUPER_ADMIN, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER)
+  async getOrganizationDashboard(@Param('orgId') orgId: string, @Res() res: Response, @User() reqUser: user): Promise<Response> {
 
     const getOrganization = await this.organizationService.getOrganizationDashboard(orgId, reqUser.id);
 
@@ -235,9 +237,12 @@ export class OrganizationController {
 
   }
 
+  /**
+   * @returns Organization details
+   */
   @Get('/:orgId')
-  @ApiOperation({ summary: 'Get an organization', description: 'Get an organization' })
-  @ApiResponse({ status: 200, description: 'Success', type: ApiResponseDto })
+  @ApiOperation({ summary: 'Get an organization', description: 'Get an organization by id' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   @ApiBearerAuth()
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER)

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -246,7 +246,7 @@ export class OrganizationController {
   @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   @ApiBearerAuth()
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER)
-  async getOrganization(@Param('orgId') orgId: string, @Res() res: Response, @User() reqUser: user): Promise<IResponseType> {
+  async getOrganization(@Param('orgId') orgId: string, @Res() res: Response, @User() reqUser: user): Promise<Response> {
 
     const getOrganization = await this.organizationService.getOrganization(orgId, reqUser.id);
 

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -62,7 +62,7 @@ export class OrganizationController {
  */
   @Get('/public-profile')
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
-  @ApiOperation({ summary: 'Get all public profile of organizations', description: 'Get all public profile of organizations.' })
+  @ApiOperation({ summary: 'Get all public profile organizations', description: 'Get all public profile organizations.' })
   @ApiQuery({
     name: 'pageNumber',
     type: Number,

--- a/apps/api-gateway/src/organization/organization.service.ts
+++ b/apps/api-gateway/src/organization/organization.service.ts
@@ -11,8 +11,9 @@ import { UpdateOrganizationDto } from './dtos/update-organization-dto';
 import { GetAllUsersDto } from '../user/dto/get-all-users.dto';
 import { IOrgRoles } from 'libs/org-roles/interfaces/org-roles.interface';
 import { organisation } from '@prisma/client';
-import { IGetOrgById, IGetOrganization, IOrgInvitationsPagination, IOrganizationDashboard } from 'apps/organization/interfaces/organization.interface';
+import { IGetOrgById, IGetOrganization, IOrgInvitationsPagination} from 'apps/organization/interfaces/organization.interface';
 import { IOrgUsers } from 'apps/user/interfaces/user.interface';
+import { IOrganizationDashboard } from '@credebl/common/interfaces/organization.interface';
 
 @Injectable()
 export class OrganizationService extends BaseService {
@@ -95,7 +96,7 @@ export class OrganizationService extends BaseService {
     const payload = { orgId, pageNumber, pageSize, search };
     return this.sendNatsMessage(this.serviceProxy, 'get-invitations-by-orgId', payload);
   }
-
+  
   async getOrganizationDashboard(orgId: string, userId: string): Promise<IOrganizationDashboard> {
     const payload = { orgId, userId };
     return this.sendNatsMessage(this.serviceProxy, 'get-organization-dashboard', payload);

--- a/apps/organization/interfaces/organization.interface.ts
+++ b/apps/organization/interfaces/organization.interface.ts
@@ -119,13 +119,6 @@ interface IOrganizationPagination {
   logoUrl: string;
 }
 
-export interface IOrganizationDashboard {
-  usersCount: number,
-  schemasCount: number,
-  credentialsCount: number,
-  presentationsCount:number
-}
-
 export interface Payload {
   pageNumber: number;
   pageSize: number;

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -6,13 +6,14 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { org_agents, org_invitations, user_org_roles } from '@prisma/client';
 
 import { CreateOrganizationDto } from '../dtos/create-organization.dto';
-import { IGetOrgById, IGetOrganization, IOrgInvitationsPagination, IOrganizationDashboard, IUpdateOrganization } from '../interfaces/organization.interface';
+import { IGetOrgById, IGetOrganization, IOrgInvitationsPagination, IUpdateOrganization } from '../interfaces/organization.interface';
 import { InternalServerErrorException } from '@nestjs/common';
 import { Invitation } from '@credebl/enum/enum';
 import { PrismaService } from '@credebl/prisma-service';
 import { UserOrgRolesService } from '@credebl/user-org-roles';
 import { organisation } from '@prisma/client';
 import { ResponseMessages } from '@credebl/common/response-messages';
+import { IOrganizationDashboard } from '@credebl/common/interfaces/organization.interface';
 
 @Injectable()
 export class OrganizationRepository {
@@ -369,7 +370,7 @@ export class OrganizationRepository {
 
     } catch (error) {
       this.logger.error(`error: ${JSON.stringify(error)}`);
-      throw new InternalServerErrorException(error);
+      throw new error;
     }
   }
 

--- a/apps/organization/src/organization.controller.ts
+++ b/apps/organization/src/organization.controller.ts
@@ -71,7 +71,8 @@ export class OrganizationController {
   async getOrganization(@Body() payload: { orgId: string; userId: string}): Promise<IGetOrgById> {
     return this.organizationService.getOrganization(payload.orgId);
   }
-/** 
+/**
+ * @param orgSlug 
  * @returns organization details
  */
   @MessagePattern({ cmd: 'get-organization-public-profile' })

--- a/apps/organization/src/organization.controller.ts
+++ b/apps/organization/src/organization.controller.ts
@@ -6,9 +6,10 @@ import { Body } from '@nestjs/common';
 import { CreateOrganizationDto } from '../dtos/create-organization.dto';
 import { BulkSendInvitationDto } from '../dtos/send-invitation.dto';
 import { UpdateInvitationDto } from '../dtos/update-invitation.dt';
-import { IGetOrgById, IGetOrganization, IOrgInvitationsPagination, IOrganizationDashboard, IUpdateOrganization, Payload } from '../interfaces/organization.interface';
+import { IGetOrgById, IGetOrganization, IOrgInvitationsPagination, IUpdateOrganization, Payload } from '../interfaces/organization.interface';
 import { organisation } from '@prisma/client';
 import { IOrgRoles } from 'libs/org-roles/interfaces/org-roles.interface';
+import { IOrganizationDashboard } from '@credebl/common/interfaces/organization.interface';
 
 @Controller()
 export class OrganizationController {
@@ -70,7 +71,9 @@ export class OrganizationController {
   async getOrganization(@Body() payload: { orgId: string; userId: string}): Promise<IGetOrgById> {
     return this.organizationService.getOrganization(payload.orgId);
   }
-
+/** 
+ * @returns organization details
+ */
   @MessagePattern({ cmd: 'get-organization-public-profile' })
   async getPublicProfile(payload: { orgSlug }): Promise<IGetOrgById> {
     return this.organizationService.getPublicProfile(payload);

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -17,13 +17,14 @@ import { BulkSendInvitationDto } from '../dtos/send-invitation.dto';
 import { UpdateInvitationDto } from '../dtos/update-invitation.dt';
 import { NotFoundException } from '@nestjs/common';
 import { Invitation, OrgAgentType, transition } from '@credebl/enum/enum';
-import { IGetOrgById, IGetOrganization, IOrgInvitationsPagination, IOrganizationDashboard, IUpdateOrganization, IOrgAgent } from '../interfaces/organization.interface';
+import { IGetOrgById, IGetOrganization, IOrgInvitationsPagination, IUpdateOrganization, IOrgAgent } from '../interfaces/organization.interface';
 import { UserActivityService } from '@credebl/user-activity';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { map } from 'rxjs/operators';
 import { Cache } from 'cache-manager';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { IOrgRoles } from 'libs/org-roles/interfaces/org-roles.interface';
+import { IOrganizationDashboard } from '@credebl/common/interfaces/organization.interface';
 @Injectable()
 export class OrganizationService {
   constructor(
@@ -196,7 +197,7 @@ export class OrganizationService {
 
       const organizationDetails = await this.organizationRepository.getOrganization(query);
       if (!organizationDetails) {
-        throw new NotFoundException(ResponseMessages.organisation.error.profileNotFound);
+        throw new NotFoundException(ResponseMessages.organisation.error.orgProfileNotFound);
       }
 
       const credDefs = await this.organizationRepository.getCredDefByOrg(organizationDetails.id);
@@ -491,7 +492,7 @@ export class OrganizationService {
 
   async getOrgDashboard(orgId: string): Promise<IOrganizationDashboard> {
     try {
-      return this.organizationRepository.getOrgDashboard(orgId);
+            return this.organizationRepository.getOrgDashboard(orgId);
     } catch (error) {
       this.logger.error(`In create organization : ${JSON.stringify(error)}`);
       throw new RpcException(error.response ? error.response : error);

--- a/libs/common/src/interfaces/organization.interface.ts
+++ b/libs/common/src/interfaces/organization.interface.ts
@@ -1,0 +1,6 @@
+export interface IOrganizationDashboard {
+    usersCount: number,
+    schemasCount: number,
+    credentialsCount: number,
+    presentationsCount:number
+  }

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -74,6 +74,7 @@ export const ResponseMessages = {
         error: {
             exists: 'An organization name is already exist',
             orgProfileNotFound: 'Organization public profile not found',
+            orgSlugIsRequired: 'Organization public profile not found',
             rolesNotExist: 'Provided roles not exists in the platform',
             orgProfile: 'Organization profile not found',
             userNotFound: 'User not found for the given organization',
@@ -84,7 +85,10 @@ export const ResponseMessages = {
             orgNotFound: 'Organization not found',
             orgNotMatch: 'Organization does not have access',
             invitationStatusInvalid: 'Unable to delete invitation with accepted/rejected status',
-            invalidOrgId:'Invalid format for orgId'
+            invalidOrgId:'Invalid format for orgId',
+            orgIdIsRequired:'OrgId is required'
+            
+
         }
     },
 

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -73,7 +73,7 @@ export const ResponseMessages = {
         },
         error: {
             exists: 'An organization name is already exist',
-            profileNotFound: 'Organization public profile not found',
+            orgProfileNotFound: 'Organization public profile not found',
             rolesNotExist: 'Provided roles not exists in the platform',
             orgProfile: 'Organization profile not found',
             userNotFound: 'User not found for the given organization',
@@ -83,7 +83,8 @@ export const ResponseMessages = {
             notFound: 'Organization agent not found',
             orgNotFound: 'Organization not found',
             orgNotMatch: 'Organization does not have access',
-            invitationStatusInvalid: 'Unable to delete invitation with accepted/rejected status'
+            invitationStatusInvalid: 'Unable to delete invitation with accepted/rejected status',
+            invalidOrgId:'Invalid format for orgId'
         }
     },
 


### PR DESCRIPTION
Refactored following APIs from organization module:

- GET `/orgs/public-profiles/{orgSlug}` Fetch organization details.
- GET `/orgs/dashboard/{orgId}` Get dashboard details.
- GET `/orgs/{orgId}` Get an organization.

### What ###
- Ensured consistency of API status codes.
- Handled error and success messages.
- Tested with both positive and negative scenarios.


### How ###
- Checked and standardized API status codes to ensure a uniform response.

### Why ###
- Ensuring consistent API status codes improves communication between different components of the system and enhances overall reliability.

