### PR TITLE
refactor: create ecosystem and get ecosystem APIs

### DIFF
--- a/apps/api-gateway/src/authz/guards/ecosystem-roles.guard.ts
+++ b/apps/api-gateway/src/authz/guards/ecosystem-roles.guard.ts
@@ -1,4 +1,4 @@
-import { CanActivate, ExecutionContext, Logger } from '@nestjs/common';
+import { BadRequestException, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
 
 import { HttpException } from '@nestjs/common';
 import { HttpStatus } from '@nestjs/common';
@@ -7,6 +7,7 @@ import { ECOSYSTEM_ROLES_KEY } from '../decorators/roles.decorator';
 import { Reflector } from '@nestjs/core';
 import { EcosystemService } from '../../ecosystem/ecosystem.service';
 import { EcosystemRoles } from '@credebl/enum/enum';
+import { ResponseMessages } from '@credebl/common/response-messages';
 
 @Injectable()
 export class EcosystemRolesGuard implements CanActivate {
@@ -32,6 +33,16 @@ export class EcosystemRolesGuard implements CanActivate {
     const req = context.switchToHttp().getRequest();
 
     const { user } = req;
+
+    req.params.ecosystemId = req.params?.ecosystemId ? req.params?.ecosystemId?.trim() : '';
+    req.query.ecosystemId = req.query?.ecosystemId ? req.query?.ecosystemId?.trim() : '';
+    req.body.ecosystemId = req.body?.ecosystemId ? req.body?.ecosystemId?.trim() : '';
+
+    const ecosystemId = req.params.ecosystemId || req.query.ecosystemId || req.body.ecosystemId;
+  
+    if (!ecosystemId) {
+      throw new BadRequestException(ResponseMessages.organisation.error.ecosystemIdIsRequired);
+    }
 
     if ((req.params.orgId || req.query.orgId || req.body.orgId) 
     && (req.params.ecosystemId || req.query.ecosystemId || req.body.ecosystemId)) {

--- a/apps/api-gateway/src/ecosystem/dtos/create-ecosystem-dto.ts
+++ b/apps/api-gateway/src/ecosystem/dtos/create-ecosystem-dto.ts
@@ -1,7 +1,7 @@
 import { ApiExtraModels, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsBoolean, IsNotEmpty, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
-import { Transform } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import { trim } from '@credebl/common/cast.helper';
 
 @ApiExtraModels()
@@ -27,10 +27,11 @@ export class CreateEcosystemDto {
     @IsOptional()
     @Transform(({ value }) => trim(value))
     @IsString({ message: 'tag must be in string format.' })
-    tags? = '';
+    @Type(() => String)
+    tags? = ' ';
   
     @ApiPropertyOptional()
-    
+
     userId: string;
   
     @ApiPropertyOptional()

--- a/apps/api-gateway/src/ecosystem/dtos/create-ecosystem-dto.ts
+++ b/apps/api-gateway/src/ecosystem/dtos/create-ecosystem-dto.ts
@@ -28,10 +28,8 @@ export class CreateEcosystemDto {
     @Transform(({ value }) => trim(value))
     @IsString({ message: 'tag must be in string format.' })
     @Type(() => String)
-    tags? = ' ';
+    tags?: string;
   
-    @ApiPropertyOptional()
-
     userId: string;
   
     @ApiPropertyOptional()

--- a/apps/api-gateway/src/ecosystem/ecosystem.controller.ts
+++ b/apps/api-gateway/src/ecosystem/ecosystem.controller.ts
@@ -5,7 +5,7 @@ import { Post, Get } from '@nestjs/common';
 import { Body } from '@nestjs/common';
 import { Res } from '@nestjs/common';
 import { RequestCredDefDto, RequestSchemaDto } from './dtos/request-schema.dto';
-import IResponseType from '@credebl/common/interfaces/response.interface';
+import IResponse from '@credebl/common/interfaces/response.interface';
 import { HttpStatus } from '@nestjs/common';
 import { Response } from 'express';
 import { ApiResponseDto } from '../dtos/apiResponse.dto';
@@ -72,7 +72,7 @@ export class EcosystemController {
   ): Promise<Response> {
 
     const ecosystemList = await this.ecosystemService.getEndorsementTranasactions(ecosystemId, orgId, getAllEndorsementsDto);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.ecosystem.success.fetchEndorsors,
       data: ecosystemList.response
@@ -110,7 +110,7 @@ export class EcosystemController {
   ): Promise<Response> {
 
     const schemaList = await this.ecosystemService.getAllEcosystemSchemas(ecosystemId, orgId, getAllEcosystemSchemaDto);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.ecosystem.success.allschema,
       data: schemaList.response
@@ -118,9 +118,12 @@ export class EcosystemController {
     return res.status(HttpStatus.OK).json(finalResponse);
   }
 
+  /**
+   * @returns Ecosystem details 
+   */
   @Get('/:orgId')
   @ApiOperation({ summary: 'Get all organization ecosystems', description: 'Get all existing ecosystems of an specific organization' })
-  @ApiResponse({ status: 200, description: 'Success', type: ApiResponseDto })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER)
   @ApiBearerAuth()
@@ -129,17 +132,23 @@ export class EcosystemController {
     @Res() res: Response
   ): Promise<Response> {
     const ecosystemList = await this.ecosystemService.getAllEcosystem(orgId);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.ecosystem.success.fetch,
-      data: ecosystemList.response
+      data: ecosystemList
     };
     return res.status(HttpStatus.OK).json(finalResponse);
   }
 
+ /**
+  * @param ecosystemId 
+  * @param orgId 
+  * @returns Ecosystem dashboard details
+  */ 
+
   @Get('/:ecosystemId/:orgId/dashboard')
   @ApiOperation({ summary: 'Get ecosystem dashboard details', description: 'Get ecosystem dashboard details' })
-  @ApiResponse({ status: 200, description: 'Success', type: ApiResponseDto })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   @UseGuards(AuthGuard('jwt'), OrgRolesGuard, EcosystemRolesGuard)
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER)
   @EcosystemsRoles(EcosystemRoles.ECOSYSTEM_OWNER, EcosystemRoles.ECOSYSTEM_LEAD, EcosystemRoles.ECOSYSTEM_MEMBER)
@@ -147,10 +156,10 @@ export class EcosystemController {
   async getEcosystemDashboardDetails(@Param('ecosystemId') ecosystemId: string, @Param('orgId') orgId: string, @Res() res: Response): Promise<Response> {
 
     const getEcosystemDetails = await this.ecosystemService.getEcosystemDashboardDetails(ecosystemId, orgId);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.ecosystem.success.getEcosystemDashboard,
-      data: getEcosystemDetails.response
+      data: getEcosystemDetails
     };
     return res.status(HttpStatus.OK).json(finalResponse);
 
@@ -191,7 +200,7 @@ export class EcosystemController {
       throw new BadRequestException(ResponseMessages.ecosystem.error.invalidInvitationStatus);
     }
     const getEcosystemInvitation = await this.ecosystemService.getEcosystemInvitations(getAllInvitationsDto, user.email, getAllInvitationsDto.status);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.ecosystem.success.getInvitation,
       data: getEcosystemInvitation.response
@@ -231,7 +240,7 @@ export class EcosystemController {
 
     const getInvitationById = await this.ecosystemService.getInvitationsByEcosystemId(ecosystemId, getAllInvitationsDto, String(user.id));
 
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.organisation.success.getInvitation,
       data: getInvitationById.response
@@ -273,7 +282,7 @@ export class EcosystemController {
     @Query() getEcosystemMembers: GetAllEcosystemMembersDto,
     @Res() res: Response): Promise<Response> {
     const members = await this.ecosystemService.getEcosystemMembers(ecosystemId, getEcosystemMembers);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.ecosystem.success.fetchMembers,
       data: members?.response
@@ -293,7 +302,7 @@ export class EcosystemController {
     requestSchemaPayload.userId = user.id;
     
     await this.ecosystemService.schemaEndorsementRequest(requestSchemaPayload, orgId, ecosystemId);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.CREATED,
       message: ResponseMessages.ecosystem.success.schemaRequest
     };
@@ -302,14 +311,13 @@ export class EcosystemController {
 
 
   /**
-   * 
    * @param createOrgDto 
    * @param res 
-   * @returns Ecosystem create response
+   * @returns Ecosystem details
    */
   @Post('/:orgId')
-  @ApiOperation({ summary: 'Create a new ecosystem', description: 'Create an ecosystem' })
-  @ApiResponse({ status: 201, description: 'Success', type: ApiResponseDto })
+  @ApiOperation({ summary: 'Create a new ecosystem', description: 'Create a new ecosystem' })
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'Success', type: ApiResponseDto })
   @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   @ApiBearerAuth()
   @Roles(OrgRoles.OWNER)
@@ -321,7 +329,7 @@ export class EcosystemController {
     createOrgDto.orgId = orgId;
     createOrgDto.userId = user.id;
     await this.ecosystemService.createEcosystem(createOrgDto);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.CREATED,
       message: ResponseMessages.ecosystem.success.create
     };
@@ -339,7 +347,7 @@ export class EcosystemController {
   async requestCredDefTransaction(@Body() requestCredDefPayload: RequestCredDefDto, @Param('orgId') orgId: string, @Param('ecosystemId') ecosystemId: string, @Res() res: Response, @User() user: user): Promise<Response> {
     requestCredDefPayload.userId = user.id;
     await this.ecosystemService.credDefEndorsementRequest(requestCredDefPayload, orgId, ecosystemId);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.CREATED,
       message: ResponseMessages.ecosystem.success.credDefRequest
     };
@@ -355,7 +363,7 @@ export class EcosystemController {
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN)
   async SignEndorsementRequests(@Param('endorsementId') endorsementId: string, @Param('ecosystemId') ecosystemId: string, @Param('orgId') orgId: string, @Res() res: Response): Promise<Response> {
     await this.ecosystemService.signTransaction(endorsementId, ecosystemId);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.CREATED,
       message: ResponseMessages.ecosystem.success.sign
     };
@@ -371,7 +379,7 @@ export class EcosystemController {
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER)
   async SumbitEndorsementRequests(@Param('endorsementId') endorsementId: string, @Param('ecosystemId') ecosystemId: string, @Param('orgId') orgId: string, @Res() res: Response): Promise<Response> {
     await this.ecosystemService.submitTransaction(endorsementId, ecosystemId, orgId);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.CREATED,
       message: ResponseMessages.ecosystem.success.submit
     };
@@ -400,15 +408,11 @@ export class EcosystemController {
     @Param('orgId') orgId: string,
     @User() user: user, @Res() res: Response): Promise<Response> {
 
-    // const userId = `a1614521-02c3-493f-97e5-9e8ac1c25682`;
-    // const userEmail = `pallavicoder10@yopmail.com`;
-
-
     bulkInvitationDto.ecosystemId = ecosystemId;
 
     await this.ecosystemService.createInvitation(bulkInvitationDto, user.id, user.email);
 
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.CREATED,
       message: ResponseMessages.ecosystem.success.createInvitation
     };
@@ -435,7 +439,7 @@ export class EcosystemController {
     @Res() res: Response
   ): Promise<object> {
     await this.ecosystemService.autoSignAndSubmitTransaction();
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.ecosystem.success.AutoEndorsementTransaction
     };
@@ -463,7 +467,7 @@ export class EcosystemController {
     acceptRejectEcosystemInvitation.userId = user.id;
     const invitationRes = await this.ecosystemService.acceptRejectEcosystemInvitaion(acceptRejectEcosystemInvitation, user.email);
 
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.CREATED,
       message: invitationRes.response
     };
@@ -486,7 +490,7 @@ export class EcosystemController {
     @Res() res: Response): Promise<Response> {
     editEcosystemDto.userId = user.id;
     await this.ecosystemService.editEcosystem(editEcosystemDto, ecosystemId);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.ecosystem.success.update
     };
@@ -517,7 +521,7 @@ export class EcosystemController {
     @Res() res: Response
   ): Promise<object> {
     await this.ecosystemService.declineEndorsementRequestByLead(ecosystemId, endorsementId, orgId);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.ecosystem.success.DeclineEndorsementTransaction
     };
@@ -539,7 +543,7 @@ export class EcosystemController {
     @Res() res: Response): Promise<Response> {
 
     await this.ecosystemService.deleteEcosystemInvitations(invitationId);
-    const finalResponse: IResponseType = {
+    const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.ecosystem.success.delete
     };

--- a/apps/api-gateway/src/ecosystem/ecosystem.controller.ts
+++ b/apps/api-gateway/src/ecosystem/ecosystem.controller.ts
@@ -476,8 +476,8 @@ export class EcosystemController {
 
 
   @Put('/:ecosystemId/:orgId')
-  @ApiOperation({ summary: 'Edit ecosystem', description: 'Edit existing ecosystem' })
-  @ApiResponse({ status: 200, description: 'Success', type: ApiResponseDto })
+  @ApiOperation({ summary: 'Edit ecosystem', description: 'Edit ecosystem' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   @UseGuards(AuthGuard('jwt'), OrgRolesGuard, EcosystemRolesGuard)
   @ApiBearerAuth()
   @EcosystemsRoles(EcosystemRoles.ECOSYSTEM_OWNER, EcosystemRoles.ECOSYSTEM_LEAD)

--- a/apps/api-gateway/src/ecosystem/ecosystem.service.ts
+++ b/apps/api-gateway/src/ecosystem/ecosystem.service.ts
@@ -13,7 +13,7 @@ import { RequestSchemaDto, RequestCredDefDto } from './dtos/request-schema.dto';
 import { CreateEcosystemDto } from './dtos/create-ecosystem-dto';
 import { EditEcosystemDto } from './dtos/edit-ecosystem-dto';
 import { ecosystem } from '@prisma/client';
-import { IEcosystemDashboard } from 'apps/ecosystem/interfaces/ecosystem.interfaces';
+import { IEditEcosystem, IEcosystemDashboard } from 'apps/ecosystem/interfaces/ecosystem.interfaces';
 
 @Injectable()
 export class EcosystemService extends BaseService {
@@ -36,7 +36,7 @@ export class EcosystemService extends BaseService {
    * @param editEcosystemDto
    * @returns Ecosystem creation success
    */
-  async editEcosystem(editEcosystemDto: EditEcosystemDto, ecosystemId: string): Promise<ecosystem> {
+  async editEcosystem(editEcosystemDto: EditEcosystemDto, ecosystemId: string): Promise<IEditEcosystem> {
     const payload = { editEcosystemDto, ecosystemId };
     return this.sendNatsMessage(this.serviceProxy, 'edit-ecosystem', payload);
   }

--- a/apps/api-gateway/src/ecosystem/ecosystem.service.ts
+++ b/apps/api-gateway/src/ecosystem/ecosystem.service.ts
@@ -12,6 +12,8 @@ import { GetAllEndorsementsDto } from './dtos/get-all-endorsements.dto';
 import { RequestSchemaDto, RequestCredDefDto } from './dtos/request-schema.dto';
 import { CreateEcosystemDto } from './dtos/create-ecosystem-dto';
 import { EditEcosystemDto } from './dtos/edit-ecosystem-dto';
+import { ecosystem } from '@prisma/client';
+import { IEcosystemDashboard } from 'apps/ecosystem/interfaces/ecosystem.interfaces';
 
 @Injectable()
 export class EcosystemService extends BaseService {
@@ -24,9 +26,9 @@ export class EcosystemService extends BaseService {
    * @param createEcosystemDto
    * @returns Ecosystem creation success
    */
-  async createEcosystem(createEcosystemDto: CreateEcosystemDto): Promise<object> {
+  async createEcosystem(createEcosystemDto: CreateEcosystemDto): Promise<ecosystem> {
     const payload = { createEcosystemDto };
-    return this.sendNats(this.serviceProxy, 'create-ecosystem', payload);
+    return this.sendNatsMessage(this.serviceProxy, 'create-ecosystem', payload);
   }
 
   /**
@@ -44,9 +46,9 @@ export class EcosystemService extends BaseService {
    *
    * @returns Get all ecosystems
    */
-  async getAllEcosystem(orgId: string): Promise<{ response: object }> {
+  async getAllEcosystem(orgId: string): Promise<object> {
     const payload = { orgId };
-    return this.sendNats(this.serviceProxy, 'get-all-ecosystem', payload);
+    return this.sendNatsMessage(this.serviceProxy, 'get-all-ecosystem', payload);
   }
 
   /**
@@ -54,9 +56,9 @@ export class EcosystemService extends BaseService {
    *
    * @returns Get ecosystems dashboard card counts
    */
-  async getEcosystemDashboardDetails(ecosystemId: string, orgId: string): Promise<{ response: object }> {
+  async getEcosystemDashboardDetails(ecosystemId: string, orgId: string): Promise<IEcosystemDashboard> {
     const payload = { ecosystemId, orgId };
-    return this.sendNats(this.serviceProxy, 'get-ecosystem-dashboard-details', payload);
+    return this.sendNatsMessage(this.serviceProxy, 'get-ecosystem-dashboard-details', payload);
   }
 
   /**

--- a/apps/api-gateway/src/ecosystem/ecosystem.service.ts
+++ b/apps/api-gateway/src/ecosystem/ecosystem.service.ts
@@ -36,9 +36,9 @@ export class EcosystemService extends BaseService {
    * @param editEcosystemDto
    * @returns Ecosystem creation success
    */
-  async editEcosystem(editEcosystemDto: EditEcosystemDto, ecosystemId: string): Promise<object> {
+  async editEcosystem(editEcosystemDto: EditEcosystemDto, ecosystemId: string): Promise<ecosystem> {
     const payload = { editEcosystemDto, ecosystemId };
-    return this.sendNats(this.serviceProxy, 'edit-ecosystem', payload);
+    return this.sendNatsMessage(this.serviceProxy, 'edit-ecosystem', payload);
   }
 
   /**

--- a/apps/api-gateway/src/ecosystem/ecosystem.service.ts
+++ b/apps/api-gateway/src/ecosystem/ecosystem.service.ts
@@ -12,8 +12,7 @@ import { GetAllEndorsementsDto } from './dtos/get-all-endorsements.dto';
 import { RequestSchemaDto, RequestCredDefDto } from './dtos/request-schema.dto';
 import { CreateEcosystemDto } from './dtos/create-ecosystem-dto';
 import { EditEcosystemDto } from './dtos/edit-ecosystem-dto';
-import { ecosystem } from '@prisma/client';
-import { IEditEcosystem, IEcosystemDashboard } from 'apps/ecosystem/interfaces/ecosystem.interfaces';
+import { IEditEcosystem, IEcosystemDashboard, ICreateEcosystem, EcosystemDetailsResult } from 'apps/ecosystem/interfaces/ecosystem.interfaces';
 
 @Injectable()
 export class EcosystemService extends BaseService {
@@ -26,7 +25,7 @@ export class EcosystemService extends BaseService {
    * @param createEcosystemDto
    * @returns Ecosystem creation success
    */
-  async createEcosystem(createEcosystemDto: CreateEcosystemDto): Promise<ecosystem> {
+  async createEcosystem(createEcosystemDto: CreateEcosystemDto): Promise<ICreateEcosystem> {
     const payload = { createEcosystemDto };
     return this.sendNatsMessage(this.serviceProxy, 'create-ecosystem', payload);
   }
@@ -46,7 +45,7 @@ export class EcosystemService extends BaseService {
    *
    * @returns Get all ecosystems
    */
-  async getAllEcosystem(orgId: string): Promise<object> {
+  async getAllEcosystem(orgId: string): Promise<EcosystemDetailsResult> {
     const payload = { orgId };
     return this.sendNatsMessage(this.serviceProxy, 'get-all-ecosystem', payload);
   }

--- a/apps/api-gateway/src/organization/dtos/get-all-organizations.dto.ts
+++ b/apps/api-gateway/src/organization/dtos/get-all-organizations.dto.ts
@@ -1,15 +1,15 @@
 import { Transform, Type } from 'class-transformer';
-// import { SortValue } from '../../enum';
 import { toNumber } from '@credebl/common/cast.helper';
-
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional } from 'class-validator';
+import { IsInt, IsOptional, Min } from 'class-validator';
 
 export class GetAllOrganizationsDto {
     @ApiProperty({ required: false })
     @IsOptional()
     @Type(() => Number)
     @Transform(({ value }) => toNumber(value))
+    @IsInt({ message: 'Page number must be a positive number' })
+    @Min(1, { message: 'Page number must be greater than or equal to 1' })
     pageNumber = 1;
 
     @ApiProperty({ required: false })
@@ -20,7 +20,7 @@ export class GetAllOrganizationsDto {
     @ApiProperty({ required: false })
     @IsOptional()
     @Type(() => Number)
-    @Transform(({ value }) => toNumber(value))
+    @IsInt({ message: 'Page Size must be a positive number' })
+    @Min(1, { message: 'Page Size must be greater than or equal to 1' })
     pageSize = 10;
-
 }

--- a/apps/api-gateway/src/organization/dtos/send-invitation.dto.ts
+++ b/apps/api-gateway/src/organization/dtos/send-invitation.dto.ts
@@ -27,7 +27,7 @@ export class BulkSendInvitationDto {
         example: [
             {
                 email: 'awqx@getnada.com',
-                orgRoleId: ['1,2,3']
+                orgRoleId: [1, 2, 3]
             }
         ]
     })

--- a/apps/api-gateway/src/organization/dtos/update-organization-dto.ts
+++ b/apps/api-gateway/src/organization/dtos/update-organization-dto.ts
@@ -20,6 +20,7 @@ export class UpdateOrganizationDto {
 
     @ApiPropertyOptional()
     @Transform(({ value }) => trim(value))
+    @IsNotEmpty({ message: 'Description is required.' })
     @MinLength(2, { message: 'Description must be at least 2 characters.' })
     @MaxLength(255, { message: 'Description must be at most 255 characters.' })
     @IsString({ message: 'Description must be in string format.' })

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -1,4 +1,4 @@
-import { ApiBearerAuth, ApiForbiddenResponse, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiExcludeEndpoint, ApiForbiddenResponse, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { CommonService } from '@credebl/common';
 import { Controller, Get, Put, Param, UseGuards, UseFilters, Post, Body, Res, HttpStatus, Query, Delete, ParseUUIDPipe, BadRequestException } from '@nestjs/common';
 import { OrganizationService } from './organization.service';
@@ -45,6 +45,7 @@ export class OrganizationController {
 
   @Get('/profile/:orgId')
   @ApiOperation({ summary: 'Organization Profile', description: 'Get organization profile details' })
+  @ApiExcludeEndpoint()
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   async getOrgPofile(@Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }}))
   orgId: string, @Res() res: Response): Promise<Response> {

--- a/apps/ecosystem/interfaces/ecosystem.interfaces.ts
+++ b/apps/ecosystem/interfaces/ecosystem.interfaces.ts
@@ -359,3 +359,18 @@ export interface IEditEcosystem {
   autoEndorsement: boolean;
   ledgers: Prisma.JsonValue;
 }
+
+export interface ICreateEcosystem {
+  id: string;
+  name: string;
+  description: string;
+  tags: string;
+  createDateTime: Date;
+  createdBy: string;
+  lastChangedDateTime: Date;
+  lastChangedBy: string;
+  deletedAt: Date;
+  logoUrl: string;
+  autoEndorsement: boolean;
+  ledgers: Prisma.JsonValue;
+}

--- a/apps/ecosystem/interfaces/ecosystem.interfaces.ts
+++ b/apps/ecosystem/interfaces/ecosystem.interfaces.ts
@@ -285,3 +285,41 @@ export interface TransactionPayload {
   ecosystemLeadAgentEndPoint?: string;
   orgId?: string;
 }
+
+export interface IEcosystemDashboard {
+    ecosystem: IEcosystemDetails[];
+    membersCount: number;
+    endorsementsCount: number;
+    ecosystemLead: EcosystemLeadDetails;
+  };
+
+ interface IEcosystemDetails {
+  id: string;
+  name: string;
+  description: string;
+  tags: string; 
+  createDateTime: Date;
+  createdBy: string;
+  lastChangedDateTime: Date;
+  lastChangedBy: string;
+  deletedAt: Date;
+  logoUrl: string;
+  autoEndorsement: boolean;
+  ledgers: string[];
+}
+
+interface EcosystemLeadDetails {
+  role: string;
+  orgName: string;
+  config: IEcosystemConfigDetails[];
+}
+ interface IEcosystemConfigDetails {
+  id: string;
+  key: string;
+  value: string;
+  createDateTime: Date;
+  createdBy: string;
+  lastChangedDateTime: Date;
+  lastChangedBy: string;
+  deletedAt: Date;
+}

--- a/apps/ecosystem/interfaces/ecosystem.interfaces.ts
+++ b/apps/ecosystem/interfaces/ecosystem.interfaces.ts
@@ -344,3 +344,18 @@ interface EcosystemLeadDetails {
   lastChangedBy: string;
   deletedAt: Date;
 }
+
+export interface IEditEcosystem {
+  id: string;
+  name: string;
+  description: string;
+  tags: string;
+  createDateTime: Date;
+  createdBy: string;
+  lastChangedDateTime: Date;
+  lastChangedBy: string;
+  deletedAt: Date;
+  logoUrl: string;
+  autoEndorsement: boolean;
+  ledgers: Prisma.JsonValue;
+}

--- a/apps/ecosystem/src/ecosystem.controller.ts
+++ b/apps/ecosystem/src/ecosystem.controller.ts
@@ -8,8 +8,7 @@ import { AcceptRejectEcosystemInvitationDto } from '../dtos/accept-reject-ecosys
 import { FetchInvitationsPayload } from '../interfaces/invitations.interface';
 import { EcosystemMembersPayload } from '../interfaces/ecosystemMembers.interface';
 import { GetEndorsementsPayload } from '../interfaces/endorsements.interface';
-import { IEditEcosystem, IEcosystemDashboard, RequestCredDeffEndorsement, RequestSchemaEndorsement } from '../interfaces/ecosystem.interfaces';
-import { ecosystem } from '@prisma/client';
+import { IEditEcosystem, IEcosystemDashboard, RequestCredDeffEndorsement, RequestSchemaEndorsement, ICreateEcosystem, EcosystemDetailsResult } from '../interfaces/ecosystem.interfaces';
 
 @Controller()
 export class EcosystemController {
@@ -23,7 +22,7 @@ export class EcosystemController {
    */
 
   @MessagePattern({ cmd: 'create-ecosystem' })
-  async createEcosystem(@Body() payload: { createEcosystemDto }): Promise<ecosystem> {
+  async createEcosystem(@Body() payload: { createEcosystemDto }): Promise<ICreateEcosystem> {
     return this.ecosystemService.createEcosystem(payload.createEcosystemDto);
   }
 
@@ -43,7 +42,7 @@ export class EcosystemController {
    * @returns Get all ecosystem details
    */
   @MessagePattern({ cmd: 'get-all-ecosystem' })
-  async getAllEcosystems(@Body() payload: { orgId: string }): Promise<object> {
+  async getAllEcosystems(@Body() payload: { orgId: string }): Promise<EcosystemDetailsResult> {
     return this.ecosystemService.getAllEcosystem(payload);
   }
 

--- a/apps/ecosystem/src/ecosystem.controller.ts
+++ b/apps/ecosystem/src/ecosystem.controller.ts
@@ -33,7 +33,7 @@ export class EcosystemController {
    * @returns Get updated ecosystem details
    */
   @MessagePattern({ cmd: 'edit-ecosystem' })
-  async editEcosystem(@Body() payload: { editEcosystemDto; ecosystemId }): Promise<object> {
+  async editEcosystem(@Body() payload: { editEcosystemDto; ecosystemId }): Promise<ecosystem> {
     return this.ecosystemService.editEcosystem(payload.editEcosystemDto, payload.ecosystemId);
   }
 

--- a/apps/ecosystem/src/ecosystem.controller.ts
+++ b/apps/ecosystem/src/ecosystem.controller.ts
@@ -8,7 +8,8 @@ import { AcceptRejectEcosystemInvitationDto } from '../dtos/accept-reject-ecosys
 import { FetchInvitationsPayload } from '../interfaces/invitations.interface';
 import { EcosystemMembersPayload } from '../interfaces/ecosystemMembers.interface';
 import { GetEndorsementsPayload } from '../interfaces/endorsements.interface';
-import { RequestCredDeffEndorsement, RequestSchemaEndorsement } from '../interfaces/ecosystem.interfaces';
+import { IEcosystemDashboard, RequestCredDeffEndorsement, RequestSchemaEndorsement } from '../interfaces/ecosystem.interfaces';
+import { ecosystem } from '@prisma/client';
 
 @Controller()
 export class EcosystemController {
@@ -22,7 +23,7 @@ export class EcosystemController {
    */
 
   @MessagePattern({ cmd: 'create-ecosystem' })
-  async createEcosystem(@Body() payload: { createEcosystemDto }): Promise<object> {
+  async createEcosystem(@Body() payload: { createEcosystemDto }): Promise<ecosystem> {
     return this.ecosystemService.createEcosystem(payload.createEcosystemDto);
   }
 
@@ -51,7 +52,7 @@ export class EcosystemController {
    * @returns Get ecosystem dashboard details
    */
   @MessagePattern({ cmd: 'get-ecosystem-dashboard-details' })
-  async getEcosystemDashboardDetails(payload: { ecosystemId: string; orgId: string }): Promise<object> {
+  async getEcosystemDashboardDetails(payload: { ecosystemId: string; orgId: string }): Promise<IEcosystemDashboard> {
     return this.ecosystemService.getEcosystemDashboardDetails(payload.ecosystemId);
   }
 

--- a/apps/ecosystem/src/ecosystem.controller.ts
+++ b/apps/ecosystem/src/ecosystem.controller.ts
@@ -8,7 +8,7 @@ import { AcceptRejectEcosystemInvitationDto } from '../dtos/accept-reject-ecosys
 import { FetchInvitationsPayload } from '../interfaces/invitations.interface';
 import { EcosystemMembersPayload } from '../interfaces/ecosystemMembers.interface';
 import { GetEndorsementsPayload } from '../interfaces/endorsements.interface';
-import { IEcosystemDashboard, RequestCredDeffEndorsement, RequestSchemaEndorsement } from '../interfaces/ecosystem.interfaces';
+import { IEditEcosystem, IEcosystemDashboard, RequestCredDeffEndorsement, RequestSchemaEndorsement } from '../interfaces/ecosystem.interfaces';
 import { ecosystem } from '@prisma/client';
 
 @Controller()
@@ -33,7 +33,7 @@ export class EcosystemController {
    * @returns Get updated ecosystem details
    */
   @MessagePattern({ cmd: 'edit-ecosystem' })
-  async editEcosystem(@Body() payload: { editEcosystemDto; ecosystemId }): Promise<ecosystem> {
+  async editEcosystem(@Body() payload: { editEcosystemDto; ecosystemId }): Promise<IEditEcosystem> {
     return this.ecosystemService.editEcosystem(payload.editEcosystemDto, payload.ecosystemId);
   }
 

--- a/apps/ecosystem/src/ecosystem.service.ts
+++ b/apps/ecosystem/src/ecosystem.service.ts
@@ -30,7 +30,7 @@ import {
 } from '../enums/ecosystem.enum';
 import { FetchInvitationsPayload } from '../interfaces/invitations.interface';
 import { EcosystemMembersPayload } from '../interfaces/ecosystemMembers.interface';
-import { CreateEcosystem, CredDefMessage, IEcosystemDashboard, LedgerDetails, OrganizationData, RequestCredDeffEndorsement, RequestSchemaEndorsement, SaveSchema, SchemaMessage, SignedTransactionMessage, TransactionPayload, saveCredDef, submitTransactionPayload } from '../interfaces/ecosystem.interfaces';
+import { CreateEcosystem, CredDefMessage, IEditEcosystem, IEcosystemDashboard, LedgerDetails, OrganizationData, RequestCredDeffEndorsement, RequestSchemaEndorsement, SaveSchema, SchemaMessage, SignedTransactionMessage, TransactionPayload, saveCredDef, submitTransactionPayload } from '../interfaces/ecosystem.interfaces';
 import { GetAllSchemaList, GetEndorsementsPayload } from '../interfaces/endorsements.interface';
 import { CommonConstants } from '@credebl/common/common.constant';
 // eslint-disable-next-line camelcase
@@ -134,7 +134,7 @@ export class EcosystemService {
    */
 
   // eslint-disable-next-line camelcase
-  async editEcosystem(editEcosystemDto: CreateEcosystem, ecosystemId: string): Promise<ecosystem> {
+  async editEcosystem(editEcosystemDto: CreateEcosystem, ecosystemId: string): Promise<IEditEcosystem> {
     const { name, description, tags, logo, autoEndorsement, userId } = editEcosystemDto;
 
     const updateData: CreateEcosystem = {

--- a/apps/ecosystem/src/ecosystem.service.ts
+++ b/apps/ecosystem/src/ecosystem.service.ts
@@ -134,7 +134,7 @@ export class EcosystemService {
    */
 
   // eslint-disable-next-line camelcase
-  async editEcosystem(editEcosystemDto: CreateEcosystem, ecosystemId: string): Promise<object> {
+  async editEcosystem(editEcosystemDto: CreateEcosystem, ecosystemId: string): Promise<ecosystem> {
     const { name, description, tags, logo, autoEndorsement, userId } = editEcosystemDto;
 
     const updateData: CreateEcosystem = {
@@ -155,6 +155,7 @@ export class EcosystemService {
     if (!editEcosystem) {
       throw new NotFoundException(ResponseMessages.ecosystem.error.update);
     }
+
     return editEcosystem;
   }
 

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -86,7 +86,8 @@ export const ResponseMessages = {
             orgNotMatch: 'Organization does not have access',
             invitationStatusInvalid: 'Unable to delete invitation with accepted/rejected status',
             invalidOrgId:'Invalid format for orgId',
-            orgIdIsRequired:'OrgId is required'
+            orgIdIsRequired:'OrgId is required',
+            ecosystemIdIsRequired:'ecosystemId is required'
             
 
         }

--- a/libs/prisma-service/prisma/migrations/20240112134257_ecosystem_tags_optional/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20240112134257_ecosystem_tags_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ecosystem" ALTER COLUMN "tags" DROP NOT NULL;

--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -334,7 +334,7 @@ model ecosystem {
   id                   String                  @id @default(uuid()) @db.Uuid
   name                 String
   description          String
-  tags                 String
+  tags                 String?
   createDateTime       DateTime                @default(now()) @db.Timestamptz(6)
   createdBy            String                  @db.Uuid
   lastChangedDateTime  DateTime                @default(now()) @db.Timestamptz(6)


### PR DESCRIPTION
Refactored following APIs from organization module:

GET `/ecosystem/{orgId}` Get all organization ecosystems.
POST `/ecosystem/{orgId}` Create a new ecosystem.
GET `/ecosystem/{ecosystemId}/{orgId}/dashboard` Get ecosystem dashboard details
PUT `/ecosystem/{ecosystemId}/{orgId}` Edit ecosystem

### What ###
- Ensured consistency of API status codes.
- Handled error and success messages.
- Tested with both positive and negative scenarios.


### How ###
- Checked and standardized API status codes to ensure a uniform response.

### Why ###
- Ensuring consistent API status codes improves communication between different components of the system and enhances overall reliability.

