### PR TITLE
fix: user-friendly message if user not have access

### DIFF
--- a/apps/api-gateway/src/authz/guards/org-roles.guard.ts
+++ b/apps/api-gateway/src/authz/guards/org-roles.guard.ts
@@ -81,6 +81,12 @@ export class OrgRolesGuard implements CanActivate {
       throw new HttpException('organization is required', HttpStatus.BAD_REQUEST);
     }
 
-    return requiredRoles.some((role) => user.selectedOrg?.orgRoles.includes(role));
+    // Sending user friendly message if a user attempts to access an API that is inaccessible to their role
+    const roleAccess = requiredRoles.some((role) => user.selectedOrg?.orgRoles.includes(role));
+    if (!roleAccess) {
+      throw new ForbiddenException(ResponseMessages.organisation.error.roleNotMatch, { cause: new Error(), description: ResponseMessages.errorMessages.forbidden });
+    }
+
+    return roleAccess;
   }
 }

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -81,7 +81,7 @@ export const ResponseMessages = {
         error: {
             exists: 'An organization name is already exist',
             orgProfileNotFound: 'Organization public profile not found',
-            orgSlugIsRequired: 'orgslug is required',
+            orgSlugIsRequired: 'orgSlug is required',
             invitationIdIsRequired:'Invitation Id is required',
             userIdIsRequired:'UserId is required',
             rolesNotExist: 'Provided roles not exists in the platform',
@@ -101,20 +101,20 @@ export const ResponseMessages = {
             clientIdRequired:'clientId is required',
             notExistClientCred: 'Organization does not have client credentials',          
             invalidUserId:'Invalid format of userId',
-            invalidInvitationId:'Invalid format for invitaion id',
-            ecosystemIdIsRequired:'ecosystemId is required'
-            
+            invalidInvitationId:'Invalid format for invitation id',
+            ecosystemIdIsRequired:'ecosystemId is required',
+            roleNotMatch: 'User does not have access'
         }
     },
 
     fido: {
         success: {
             RegistrationOption: 'Registration option created successfully',
-            verifyRegistration: 'Verify registration sucessfully',
+            verifyRegistration: 'Verify registration successfully',
             updateUserDetails: 'User details updated successfully',
             generateAuthenticationOption: 'Authentication option generated successfully',
-            deleteDevice: 'Device deleted sucessfully',
-            updateDeviceName: 'Device name updated sucessfully',
+            deleteDevice: 'Device deleted successfully',
+            updateDeviceName: 'Device name updated successfully',
             login: 'User login successfully'
         },
         error: {
@@ -274,7 +274,7 @@ export const ResponseMessages = {
             notFound: 'Organization agent not found',
             agentUrlNotFound: 'agent url not found',
             schemaIdNotFound: 'Schema Id is required',
-            predicatesValueNotNumber: 'The attribuite value is not a number',
+            predicatesValueNotNumber: 'Attribute value is not a number',
             proofPresentationNotFound: 'Proof presentations not found',
             verifiedProofNotFound: 'Proof presentation not found',
             proofNotFound: 'Proof presentation not found',
@@ -302,7 +302,7 @@ export const ResponseMessages = {
             DeclineEndorsementTransaction: 'Endorsement request declined',
             AutoEndorsementTransaction: 'The flag for transactions has been successfully set',
             fetchMembers: 'Ecosystem members fetched successfully',
-            allschema: 'Schema details fetched sucessfully',
+            allschema: 'Schema details fetched successfully',
             AutoSignAndSubmit: 'Endorsement request approved & submitted to ledger'
         },
         error: {


### PR DESCRIPTION
### What ###
- Refactored user-friendly message if a user attempts to access an API that is inaccessible to their role
- Updated message to "User does not have access"

### Why ###
- Previously user got an "Forbidden Resource" message which is not user-friendly.

### How ###
- Added condition in `UserRoleGuard`. So that it will reflect for all the APIs.