### PR TITLE
fix: socket response for bulk issuance

### DIFF
--- a/apps/api-gateway/src/authz/socket.gateway.ts
+++ b/apps/api-gateway/src/authz/socket.gateway.ts
@@ -114,9 +114,10 @@ export class SocketGateway implements OnGatewayConnection {
   @SubscribeMessage('error-in-bulk-issuance-process')
   async handleBulkIssuanceErrorResponse(client:string, payload: ISocketInterface): Promise<void> {
     this.logger.log(`error-in-bulk-issuance-process ${payload.clientId}`);
+    const error = 'string' === typeof payload?.error ? payload?.error : payload?.error?.error;
     this.server
       .to(payload.clientId)
-      .emit('error-in-bulk-issuance-process', {error: payload.error, fileUploadId: payload.fileUploadId});
+      .emit('error-in-bulk-issuance-process', {error, fileUploadId: payload.fileUploadId});
   }
 
   @SubscribeMessage('bulk-issuance-process-retry-completed')

--- a/apps/api-gateway/src/authz/socket.gateway.ts
+++ b/apps/api-gateway/src/authz/socket.gateway.ts
@@ -108,7 +108,7 @@ export class SocketGateway implements OnGatewayConnection {
     this.logger.log(`bulk-issuance-process-completed ${payload.clientId}`);
     this.server
       .to(payload.clientId)
-      .emit('bulk-issuance-process-completed');
+      .emit('bulk-issuance-process-completed', {fileUploadId: payload.fileUploadId});
   }
 
   @SubscribeMessage('error-in-bulk-issuance-process')
@@ -116,7 +116,7 @@ export class SocketGateway implements OnGatewayConnection {
     this.logger.log(`error-in-bulk-issuance-process ${payload.clientId}`);
     this.server
       .to(payload.clientId)
-      .emit('error-in-bulk-issuance-process', payload.error);
+      .emit('error-in-bulk-issuance-process', {error: payload.error, fileUploadId: payload.fileUploadId});
   }
 
   @SubscribeMessage('bulk-issuance-process-retry-completed')

--- a/apps/api-gateway/src/interfaces/ISocket.interface.ts
+++ b/apps/api-gateway/src/interfaces/ISocket.interface.ts
@@ -6,4 +6,5 @@ export interface ISocketInterface {
     error?: string;
     connectionId?: string;
     demoFlow?: string;
+    fileUploadId?: string;
 }

--- a/apps/api-gateway/src/interfaces/ISocket.interface.ts
+++ b/apps/api-gateway/src/interfaces/ISocket.interface.ts
@@ -1,9 +1,13 @@
+interface IError {
+    error: string
+}
+
 export interface ISocketInterface {
     token?: string;
     message?: string;
     clientSocketId?: string;
     clientId?: string;
-    error?: string;
+    error?: string | IError;
     connectionId?: string;
     demoFlow?: string;
     fileUploadId?: string;

--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -1004,7 +1004,7 @@ export class IssuanceService {
       fileUploadData.detailError = `${JSON.stringify(error)}`;
       if (!isErrorOccurred) {
         isErrorOccurred = true;
-        socket.emit('error-in-bulk-issuance-process', { clientId: jobDetails.clientId, error });
+        socket.emit('error-in-bulk-issuance-process', { clientId: jobDetails.clientId, fileUploadId: jobDetails.fileUploadId, error });
       }
 
     }
@@ -1018,7 +1018,7 @@ export class IssuanceService {
 
         if (!jobDetails.isRetry) {
           this.cacheManager.del(jobDetails.cacheId);
-          socket.emit('bulk-issuance-process-completed', { clientId: jobDetails.clientId });
+          socket.emit('bulk-issuance-process-completed', {clientId: jobDetails.clientId, fileUploadId: jobDetails.fileUploadId});
         } else {
           socket.emit('bulk-issuance-process-retry-completed', { clientId: jobDetails.clientId });
         }


### PR DESCRIPTION
## What?
Updated socket responses for bulk issuance.

## Why?
Requires `fileUploadId` to check the history of recently processed issuance.