### PR TITLE
fix: unauthorized error message

### DIFF
--- a/apps/api-gateway/src/authz/jwt.strategy.ts
+++ b/apps/api-gateway/src/authz/jwt.strategy.ts
@@ -1,10 +1,9 @@
 import * as dotenv from 'dotenv';
 
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException, NotFoundException } from '@nestjs/common';
 
 import { JwtPayload } from './jwt-payload.interface';
-import { NotFoundException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { UserService } from '../user/user.service';
 import * as jwt from 'jsonwebtoken';

--- a/apps/api-gateway/src/authz/jwt.strategy.ts
+++ b/apps/api-gateway/src/authz/jwt.strategy.ts
@@ -1,7 +1,7 @@
 import * as dotenv from 'dotenv';
 
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 
 import { JwtPayload } from './jwt-payload.interface';
 import { NotFoundException } from '@nestjs/common';
@@ -30,6 +30,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       secretOrKeyProvider: (request, jwtToken, done) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const decodedToken: any = jwt.decode(jwtToken);
+
+        if (!decodedToken) {
+          throw new UnauthorizedException(ResponseMessages.user.error.invalidAccessToken);
+        }
 
         const audiance = decodedToken.iss.toString();
         const jwtOptions = {

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -59,8 +59,8 @@ export const ResponseMessages = {
             invitationStatusUpdateInvalid: 'Status update is invalid. Request is already',
             resetSamePassword: 'New password should not be the current password',
             resetPasswordLink: 'Unable to create reset password token',
-            invalidResetLink: 'Invalid reset password link or expired',
-            invalidAccessToken: 'Invalid access token'
+            invalidResetLink: 'Invalid or expired reset password link',
+            invalidAccessToken: 'Authentication failed'
         }
     },
     organisation: {

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -59,7 +59,8 @@ export const ResponseMessages = {
             invitationStatusUpdateInvalid: 'Status update is invalid. Request is already',
             resetSamePassword: 'New password should not be the current password',
             resetPasswordLink: 'Unable to create reset password token',
-            invalidResetLink: 'Invalid reset password link or expired'
+            invalidResetLink: 'Invalid reset password link or expired',
+            invalidAccessToken: 'Invalid access token'
         }
     },
     organisation: {


### PR DESCRIPTION
## What?
Updated unauthorized error message when a user tries to use API with the invalid access token
Previous response:
```
{
  "statusCode": 500,
  "message": "Cannot read properties of null (reading 'iss')",
  "error": "Internal Server error"
}
```
Refactored response:
```
{
  "statusCode": 401,
  "message": "Invalid access token",
  "error": "Unauthorized"
}
```

## Why?
If an unauthorized user tries to access API then it should return a proper error message.