### PR TITLE
feat: required attributes in create schema API

### DIFF
--- a/apps/api-gateway/src/dtos/create-schema.dto.ts
+++ b/apps/api-gateway/src/dtos/create-schema.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { ArrayMinSize, IsArray, IsBoolean, IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
@@ -23,6 +23,11 @@ class AttributeValue {
     @Transform(({ value }) => trim(value))
     @IsNotEmpty({ message: 'displayName is required' })
     displayName: string;
+
+    @ApiProperty()
+    @IsBoolean()
+    @IsNotEmpty({ message: 'isRequired property is required' })
+    isRequired: boolean;
 }
 
 export class CreateSchemaDto {
@@ -44,12 +49,14 @@ export class CreateSchemaDto {
             {
                 attributeName: 'name',
                 schemaDataType: 'string',
-                displayName: 'Name'
+                displayName: 'Name',
+                isRequired: 'true'
             }
         ]
     })
     @IsArray({ message: 'attributes must be an array' })
     @IsNotEmpty({ message: 'attributes are required' })
+    @ArrayMinSize(1)
     @ValidateNested({ each: true })
     @Type(() => AttributeValue)
     attributes: AttributeValue[];

--- a/apps/api-gateway/src/ecosystem/dtos/request-schema.dto.ts
+++ b/apps/api-gateway/src/ecosystem/dtos/request-schema.dto.ts
@@ -1,24 +1,34 @@
-import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
-import { IsArray, IsBoolean, IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { ArrayMinSize, IsArray, IsBoolean, IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { trim } from '@credebl/common/cast.helper';
 
 
-@ApiExtraModels()
+class AttributeValues {
 
-class AttributeValue {
-
+  @ApiProperty()
   @IsString()
-  @IsNotEmpty({ message: 'attributeName is required.' })
+  @Transform(({ value }) => trim(value))
+  @IsNotEmpty({ message: 'attributeName is required' })
   attributeName: string;
 
+  @ApiProperty()
   @IsString()
-  @IsNotEmpty({ message: 'schemaDataType is required.' })
+  @Transform(({ value }) => trim(value))
+  @IsNotEmpty({ message: 'schemaDataType is required' })
   schemaDataType: string;
 
+  @ApiProperty()
   @IsString()
-  @IsNotEmpty({ message: 'displayName is required.' })
+  @Transform(({ value }) => trim(value))
+  @IsNotEmpty({ message: 'displayName is required' })
   displayName: string;
+
+  @ApiProperty()
+  @IsBoolean()
+  @IsNotEmpty({ message: 'isRequired property is required' })
+  isRequired: boolean;
+
 }
 
 
@@ -37,17 +47,22 @@ export class RequestSchemaDto {
   version: string;
 
   @ApiProperty({
+    type: [AttributeValues],
     'example': [
       {
         attributeName: 'name',
         schemaDataType: 'string',
-        displayName: 'Name'
+        displayName: 'Name',
+        isRequired: 'true'
       }
     ]
   })
   @IsArray({ message: 'attributes must be an array' })
-  @IsNotEmpty({ message: 'please provide valid attributes' })
-  attributes: AttributeValue[];
+  @IsNotEmpty({ message: 'attributes are required' })
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => AttributeValues)
+  attributes: AttributeValues[];
 
   @ApiProperty()
   @IsBoolean({ message: 'endorse must be a boolean.' })

--- a/apps/api-gateway/src/ecosystem/dtos/request-schema.dto.ts
+++ b/apps/api-gateway/src/ecosystem/dtos/request-schema.dto.ts
@@ -15,12 +15,6 @@ class AttributeValues {
   @ApiProperty()
   @IsString()
   @Transform(({ value }) => trim(value))
-  @IsNotEmpty({ message: 'schemaDataType is required' })
-  schemaDataType: string;
-
-  @ApiProperty()
-  @IsString()
-  @Transform(({ value }) => trim(value))
   @IsNotEmpty({ message: 'displayName is required' })
   displayName: string;
 
@@ -28,6 +22,12 @@ class AttributeValues {
   @IsBoolean()
   @IsNotEmpty({ message: 'isRequired property is required' })
   isRequired: boolean;
+
+  @ApiProperty()
+  @IsString()
+  @Transform(({ value }) => trim(value))
+  @IsNotEmpty({ message: 'schemaDataType is required' })
+  schemaDataType: string;
 
 }
 

--- a/apps/api-gateway/src/issuance/dtos/issuance.dto.ts
+++ b/apps/api-gateway/src/issuance/dtos/issuance.dto.ts
@@ -19,6 +19,12 @@ class Attribute {
     @IsDefined()
     @Transform(({ value }) => trim(value))
     value: string;
+
+    @ApiProperty()
+    @IsBoolean()
+    @IsNotEmpty({ message: 'isRequired property is required' })
+    isRequired: boolean;
+
 }
 
 class CredentialsIssuanceDto {
@@ -77,17 +83,24 @@ class CredentialsIssuanceDto {
 }
 
 export class OOBIssueCredentialDto extends CredentialsIssuanceDto {
-
-    @ApiProperty({ example: [{ 'value': 'string', 'name': 'string' }] })
-    @IsArray()
-    @ValidateNested({ each: true })
-    @ArrayMinSize(1)
-    @Type(() => Attribute)
-    attributes: Attribute[];
+  @ApiProperty({
+    example: [
+      {
+        value: 'string',
+        name: 'string',
+        isRequired: 'boolean'
+      }
+    ]
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @ArrayMinSize(1)
+  @Type(() => Attribute)
+  attributes: Attribute[];
 }
 
 class CredentialOffer {
-    @ApiProperty({ example: [{ 'value': 'string', 'name': 'string' }] })
+    @ApiProperty({ example: [{ 'value': 'string', 'name': 'string', 'isRequired':'boolean' }] })
     @IsNotEmpty({ message: 'Attribute name is required' })
     @IsArray({ message: 'Attributes should be an array' })
     @ValidateNested({ each: true })
@@ -199,7 +212,7 @@ export class CredentialAttributes {
 }
 
 export class OOBCredentialDtoWithEmail {
-    @ApiProperty({ example: [{ 'emailId': 'abc@example.com', 'attributes': [{ 'value': 'string', 'name': 'string' }] }] })
+    @ApiProperty({ example: [{ 'emailId': 'abc@example.com', 'attributes': [{ 'value': 'string', 'name': 'string', 'isRequired':'boolean' }] }] })
     @IsNotEmpty({ message: 'Please provide valid attributes' })
     @IsArray({ message: 'attributes should be array' })
     @ArrayMaxSize(Number(process.env.OOB_BATCH_SIZE), { message: `Limit reached (${process.env.OOB_BATCH_SIZE} credentials max). Easily handle larger batches via seamless CSV file uploads` })

--- a/apps/issuance/interfaces/issuance.interfaces.ts
+++ b/apps/issuance/interfaces/issuance.interfaces.ts
@@ -4,6 +4,8 @@ import { IUserRequest } from '@credebl/user-request/user-request.interface';
 import { IUserRequestInterface } from 'apps/agent-service/src/interface/agent-service.interface';
 
 export interface IAttributes {
+  attributeName: string;
+  isRequired: boolean;
   name: string;
   value: string;
 }

--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -53,6 +53,26 @@ export class IssuanceService {
   async sendCredentialCreateOffer(payload: IIssuance): Promise<ICreateOfferResponse> {
     try {
       const { orgId, credentialDefinitionId, comment, connectionId, attributes } = payload || {};
+// console.log("1234567890", attributes);
+
+      const attrError = [];
+      if (0 < attributes?.length) {
+        attributes?.forEach((attribute, i) => {
+      
+            if (attribute.isRequired && !attribute.value) {
+              attrError.push(`attributes.${i}.Value of "${attribute.name}" is required`);
+              return true;
+            }
+            
+            return attribute.isRequired && !attribute.value;
+          });
+      
+        if (0 < attrError.length) {
+          throw new BadRequestException(attrError);
+        }
+        }
+      
+
       const agentDetails = await this.issuanceRepository.getAgentEndPoint(orgId);
 
       if (!agentDetails) {
@@ -118,9 +138,26 @@ export class IssuanceService {
   async sendCredentialOutOfBand(payload: OOBIssueCredentialDto): Promise<{ response: object; }> {
     try {
       const { orgId, credentialDefinitionId, comment, attributes, protocolVersion } = payload;
+
+      const attrError = [];
+      if (0 < attributes?.length) {
+        attributes?.forEach((attribute, i) => {
+      
+            if (attribute.isRequired && !attribute.value) {
+              attrError.push(`attributes.${i}.Value of "${attribute.name}" is required`);
+              return true;
+            }
+            
+            return attribute.isRequired && !attribute.value;
+          });
+      
+        if (0 < attrError.length) {
+          throw new BadRequestException(attrError);
+        }
+        }
+
       const agentDetails = await this.issuanceRepository.getAgentEndPoint(orgId);
       // eslint-disable-next-line camelcase
-      // const platformConfig: platform_config = await this.issuanceRepository.getPlatformConfigDetails();
 
       const { agentEndPoint } = agentDetails;
       if (!agentDetails) {
@@ -351,6 +388,26 @@ export class IssuanceService {
         emailId
       } = outOfBandCredential;
 
+      const attrError = [];
+if (0 < credentialOffer?.length) {
+  credentialOffer?.forEach((credential, i) => {
+  credential.attributes.forEach((attribute, i2) => {
+
+      if (attribute.isRequired && !attribute.value) {
+        attrError.push(`credentialOffer.${i}.attributes.${i2}.Value of "${attribute.name}" is required`);
+        return true;
+      }
+      
+      return attribute.isRequired && !attribute.value;
+    });
+
+  });
+
+  if (0 < attrError.length) {
+    throw new BadRequestException(attrError);
+  }
+  }
+   
       const agentDetails = await this.issuanceRepository.getAgentEndPoint(orgId);
       if (!agentDetails) {
         throw new NotFoundException(ResponseMessages.issuance.error.agentEndPointNotFound);

--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -53,7 +53,6 @@ export class IssuanceService {
   async sendCredentialCreateOffer(payload: IIssuance): Promise<ICreateOfferResponse> {
     try {
       const { orgId, credentialDefinitionId, comment, connectionId, attributes } = payload || {};
-// console.log("1234567890", attributes);
 
       const attrError = [];
       if (0 < attributes?.length) {

--- a/apps/ledger/src/schema/interfaces/schema-payload.interface.ts
+++ b/apps/ledger/src/schema/interfaces/schema-payload.interface.ts
@@ -20,9 +20,11 @@ export interface ISchema {
 }
 
 export interface IAttributeValue {
+    isRequired: boolean;    
     attributeName: string;
     schemaDataType: string;
-    displayName: string
+    displayName: string;
+
 }
 
 export interface ISchemaPayload {

--- a/apps/ledger/src/schema/schema.service.ts
+++ b/apps/ledger/src/schema/schema.service.ts
@@ -36,7 +36,7 @@ export class SchemaService extends BaseService {
     schema: ISchemaPayload,
     user: IUserRequestInterface,
     orgId: string
-  ): Promise<ISchemaData> {
+   ): Promise<ISchemaData> {
 
     let apiKey: string = await this.cacheService.get(CommonConstants.CACHE_APIKEY_KEY);
     if (!apiKey || null === apiKey || undefined === apiKey) {
@@ -82,7 +82,8 @@ export class SchemaService extends BaseService {
             const trimmedAttributes = schema.attributes.map(attribute => ({
               attributeName: attribute.attributeName.trim(),
               schemaDataType: attribute.schemaDataType,
-              displayName: attribute.displayName.trim()
+              displayName: attribute.displayName.trim(),
+              isRequired: attribute.isRequired
             }));
 
 
@@ -122,7 +123,17 @@ export class SchemaService extends BaseService {
           const did = schema.orgDid?.split(':').length >= 4 ? schema.orgDid : orgDid;
 
           const orgAgentType = await this.schemaRepository.getOrgAgentType(getAgentDetails.org_agents[0].orgAgentTypeId);
+          
           const attributeArray = trimmedAttributes.map(item => item.attributeName);
+
+          const isRequiredAttributeExists = trimmedAttributes.some(attribute => attribute.isRequired);
+
+           if (!isRequiredAttributeExists) {
+             throw new BadRequestException(
+               ResponseMessages.schema.error.atLeastOneRequired
+             );
+           }
+
           let schemaResponseFromAgentService;
           if (OrgAgentType.DEDICATED === orgAgentType) {
             const issuerId = did;

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -156,7 +156,8 @@ export const ResponseMessages = {
             credentialDefinitionNotFound: 'No credential definition exist',
             notStoredCredential: 'User credential not stored',
             agentDetailsNotFound: 'Agent details not found',
-            failedFetchSchema: 'Failed to fetch schema data'
+            failedFetchSchema: 'Failed to fetch schema data',
+            atLeastOneRequired: 'At least one of the attributes should have isReuired as `true`'
         }
     },
     credentialDefinition: {


### PR DESCRIPTION
### What
- Added `isRequired` field in create schema API in schema service.
- Done changes in dto validations for following APIs:-

1.   POST `/orgs/{orgId}/credentials/offer` Issuer create a credential offer
2.   POST `/orgs/{orgId}/credentials/oob/email` Creates a out-of-band credential offer and sends them via emails
3.   POST `/orgs/{orgId}/credentials/oob/offer` Create out-of-band credential offer

- Added `isRequired` field in request endorsement API in ecosystem service.
