### PR TITLE
feat: add support to select multiple cred-def and connections for verification(BE)

### DIFF
--- a/apps/api-gateway/src/verification/dto/request-proof.dto.ts
+++ b/apps/api-gateway/src/verification/dto/request-proof.dto.ts
@@ -22,16 +22,17 @@ export class ProofRequestAttribute {
     @ApiPropertyOptional()
     @IsString()
     @IsOptional()
+    @IsNotEmpty({ message: 'schemaId is required.' })
     schemaId?: string;
 
     @ApiPropertyOptional()
+    @ValidateIf((obj) => obj.value !== undefined)
     @IsString()
-    @IsOptional()
     @IsNotEmpty({ message: 'condition is required.' })
     condition?: string;
 
+    @ValidateIf((obj) => obj.condition !== undefined)
     @ApiPropertyOptional()
-    @IsOptional()
     @IsNotEmpty({ message: 'value is required.' })
     @IsNumberString({}, { message: 'Value must be a number' })
     value?: string;
@@ -39,6 +40,7 @@ export class ProofRequestAttribute {
     @ApiPropertyOptional()
     @IsString()
     @IsOptional()
+    @IsNotEmpty({ message: 'credDefId is required.' })
     credDefId?: string;
 }
 
@@ -68,7 +70,8 @@ class ProofPayload {
     protocolVersion: string;
 }
 
-export class RequestProofDto extends ProofPayload {
+class PresentationPayload extends ProofPayload { 
+     
     @ApiProperty()
     @IsString()
     @Transform(({ value }) => trim(value))
@@ -76,18 +79,7 @@ export class RequestProofDto extends ProofPayload {
     @IsNotEmpty({ message: 'connectionId is required.' })
     connectionId: string;
 
-    @ApiProperty({
-        'example': [
-            {
-                attributeName: 'attributeName',
-                condition: '>=',
-                value: 'predicates',
-                credDefId: 'string',
-                schemaId: 'string'
-            }
-        ],
-        type: () => [ProofRequestAttribute]
-    })
+    @ApiProperty()
     @IsArray({ message: 'attributes must be in array' })
     @ValidateNested()
     @IsObject({ each: true })
@@ -100,7 +92,7 @@ export class RequestProofDto extends ProofPayload {
     @IsString({ message: 'comment must be in string' })
     comment: string;
 
-    orgId: string;
+     orgId: string;
 
     @ApiPropertyOptional()
     @IsString({ message: 'auto accept proof must be in string' })
@@ -110,6 +102,43 @@ export class RequestProofDto extends ProofPayload {
         message: `Invalid auto accept proof. It should be one of: ${Object.values(AutoAccept).join(', ')}`
     })
     autoAcceptProof: AutoAccept;
+    
+
+}
+export class RequestProofDto  {
+
+        @ApiProperty({
+        'example': [
+            {
+                goalCode: 'string',
+                parentThreadId: 'string',
+                willConfirm: true,
+                protocolVersion: 'v1',
+                connectionId: 'string',
+                attributes: [
+                    {
+                        attributeName: 'attributeName',
+                        condition: '>=',
+                        value: 'predicates',
+                        credDefId: 'string',
+                        schemaId: 'string'
+                    }
+                ],
+                comment: 'string',
+                autoAcceptProof: 'always'
+            }
+    
+        ]
+    })
+    @IsArray({ message: 'attributes must be in array' })
+    @ArrayMaxSize(Number(process.env.OOB_BATCH_SIZE), { message: `Limit reached (${process.env.OOB_BATCH_SIZE} connections max).`})
+    @ValidateNested()
+    @IsObject({ each: true })
+    @IsNotEmpty({ message: 'please provide valid attributes' })
+    @Type(() => PresentationPayload)
+    presentationData: PresentationPayload[];
+
+    orgId: string;
 }
 
 export class OutOfBandRequestProof extends ProofPayload {

--- a/apps/api-gateway/src/verification/verification.controller.ts
+++ b/apps/api-gateway/src/verification/verification.controller.ts
@@ -179,16 +179,24 @@ export class VerificationController {
         @Body() requestProof: RequestProofDto
     ): Promise<Response> {
 
-        const attributeArray = [];
-        for (const attrData of requestProof.attributes) {
-          if (0 === attributeArray.length) {
-            attributeArray.push(Object.values(attrData)[0]);
-          } else if (!attributeArray.includes(Object.values(attrData)[0])) {
-            attributeArray.push(Object.values(attrData)[0]);
-          } else {
-            throw new BadRequestException('Please provide unique attribute names');
-          }           
+        let attributeArray = [];
+        const attributeError = [];
 
+        requestProof.presentationData.forEach((presentation, position) => {
+            presentation.attributes.forEach((attrData, index) => {
+                
+                if (0 === attributeArray.length) {
+                    attributeArray.push(Object.values(attrData)[0]);
+                } else if (!attributeArray.includes(Object.values(attrData)[0])) {
+                    attributeArray.push(Object.values(attrData)[0]);
+                } else {
+                    attributeError.push(`Duplicate attribute(s) found in presentationData at position [${position}] in attributes at position [${index}]`);
+                }
+            });
+            attributeArray = [];
+        });
+        if (0 < attributeError.length) {
+            throw new BadRequestException(attributeError);
         }
 
         requestProof.orgId = orgId;

--- a/apps/verification/src/interfaces/verification.interface.ts
+++ b/apps/verification/src/interfaces/verification.interface.ts
@@ -11,10 +11,16 @@ interface IProofRequestAttribute {
     credentialName: string;
 }
 
+export interface IPresentationPayload {
+    connectionId?: string;
+    attributes: IProofRequestAttribute[];
+    
+}
 export interface IRequestProof {
     orgId: string;
     connectionId?: string;
     attributes: IProofRequestAttribute[];
+    presentationData: IPresentationPayload[];
     comment: string;
     autoAcceptProof: AutoAccept;
     protocolVersion?: string;

--- a/apps/verification/src/verification.controller.ts
+++ b/apps/verification/src/verification.controller.ts
@@ -38,7 +38,7 @@ export class VerificationController {
    * @returns Requested proof presentation details
    */
   @MessagePattern({ cmd: 'send-proof-request' })
-  async sendProofRequest(payload: { requestProof: IRequestProof, user: IUserRequest }): Promise<string> {
+  async sendProofRequest(payload: { requestProof: IRequestProof, user: IUserRequest }): Promise<string[]> {
     return this.verificationService.sendProofRequest(payload.requestProof);
   }
 


### PR DESCRIPTION
### What 
- Done Changes in payload of POST `/orgs/{orgId}/proofs` Sends a proof request API.
-  Added configurable maximum limit for multi-connection proof requests.(can be configurable in .env file).
-  Changed API payload structure to select mutliple connections in single proof request.
- Applied dto level validations for empty and required fields.

### Why 
- To accommodate new requirements and improve the efficiency of the proof request process, the payload structure is being revised.
- Providing flexibility to organizations in managing their proof request by allowing them to define a maximum limit based on their specific needs.

### How
- Enhanced the back-end logic to process both single and multiple connection IDs when handling proof requests, maintaining compatibility with existing API structures.