### PR TITLE
refactor: cred-def controller APIs

### DIFF
--- a/apps/api-gateway/src/credential-definition/credential-definition.controller.ts
+++ b/apps/api-gateway/src/credential-definition/credential-definition.controller.ts
@@ -31,14 +31,14 @@ export class CredentialDefinitionController {
 
   @Get('/orgs/:orgId/cred-defs/:credDefId')
   @ApiOperation({
-    summary: 'Get an existing credential definition by Id',
-    description: 'Get an existing credential definition by Id'
+    summary: 'Get credential definition by credential definition Id',
+    description: 'Get credential definition details by credential definition Id'
   })
   @ApiResponse({ status: HttpStatus.CREATED, description: 'Success', type: ApiResponseDto })
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER)
   @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   async getCredentialDefinitionById(
-    @Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(`Invalid format for orgId`); }})) orgId: string,
+    @Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string,
     @Param('credDefId') credentialDefinitionId: string,
     @Res() res: Response
   ): Promise<Response> {
@@ -53,8 +53,8 @@ export class CredentialDefinitionController {
 
   @Get('/verifiation/cred-defs/:schemaId')
   @ApiOperation({
-    summary: 'Get an existing credential definitions by schema Id',
-    description: 'Get an existing credential definitions by schema Id'
+    summary: 'Get all credential definitions by schema Id',
+    description: 'Get all credential definitions by schema Id for verification'
   })
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   @UseGuards(AuthGuard('jwt'))
@@ -74,13 +74,13 @@ export class CredentialDefinitionController {
 
   @Get('/orgs/:orgId/cred-defs')
   @ApiOperation({
-    summary: 'Fetch all credential definitions of provided organization id with pagination',
-    description: 'Fetch all credential definitions from metadata saved in database of provided organization id.'
+    summary: 'Fetch all credential definitions by organization Id',
+    description: 'Fetch all credential definitions of provided organization Id with pagination'
   })
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER)
   @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   async getAllCredDefs(
-    @Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(`Invalid format for orgId`); }})) orgId: string,
+    @Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string,
     @Query() getAllCredDefs: GetAllCredDefsDto,
     @User() user: IUserRequestInterface,
     @Res() res: Response
@@ -100,14 +100,14 @@ export class CredentialDefinitionController {
 
   @Get('/orgs/:orgId/bulk/cred-defs')
   @ApiOperation({
-    summary: 'Fetch all credential definition for bulk opeartion',
-    description: 'Fetch all credential definition from metadata saved in database for bulk opeartion.'
+    summary: 'Fetch all credential definitions for bulk opeartion',
+    description: 'Retrieve all credential definitions for bulk operation'
   })
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER)
   @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   async getAllCredDefAndSchemaForBulkOperation(
-    @Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(`Invalid format for orgId`); }})) orgId: string,
+    @Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string,
     @Res() res: Response
   ): Promise<Response> {
     const credentialsDefinitionDetails = await this.credentialDefinitionService.getAllCredDefAndSchemaForBulkOperation(orgId);
@@ -130,7 +130,7 @@ export class CredentialDefinitionController {
   async createCredentialDefinition(
     @User() user: IUserRequestInterface,
     @Body() credDef: CreateCredentialDefinitionDto,
-    @Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(`Invalid format for orgId`); }})) orgId: string,
+    @Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string,
     @Res() res: Response
   ): Promise<Response> {
 

--- a/apps/api-gateway/src/credential-definition/credential-definition.controller.ts
+++ b/apps/api-gateway/src/credential-definition/credential-definition.controller.ts
@@ -61,12 +61,13 @@ export class CredentialDefinitionController {
   async getCredentialDefinitionBySchemaId(
     @Param('schemaId') schemaId: string,
     @Res() res: Response
-  ): Promise<object> {
+  ): Promise<Response> {
+    
     const credentialsDefinitions = await this.credentialDefinitionService.getCredentialDefinitionBySchemaId(schemaId);
-    const credDefResponse: IResponseType = {
+    const credDefResponse: IResponse = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.credentialDefinition.success.fetch,
-      data: credentialsDefinitions.response
+      data: credentialsDefinitions
     };
     return res.status(HttpStatus.OK).json(credDefResponse);
   }

--- a/apps/api-gateway/src/credential-definition/credential-definition.service.ts
+++ b/apps/api-gateway/src/credential-definition/credential-definition.service.ts
@@ -4,7 +4,8 @@ import { CreateCredentialDefinitionDto } from './dto/create-cred-defs.dto';
 import { BaseService } from '../../../../libs/service/base.service';
 import { IUserRequestInterface } from '../interfaces/IUserRequestInterface';
 import { GetAllCredDefsDto } from '../dtos/get-cred-defs.dto';
-import { ICredDefs } from './interfaces';
+import { ICredDef, ICredDefs, ICredentialDefinition } from './interfaces';
+import { ICredDefData } from '@credebl/common/interfaces/cred-def.interface';
 
 @Injectable()
 export class CredentialDefinitionService extends BaseService {
@@ -15,20 +16,19 @@ export class CredentialDefinitionService extends BaseService {
     super('CredentialDefinitionService');
   }
 
-  createCredentialDefinition(credDef: CreateCredentialDefinitionDto, user: IUserRequestInterface): Promise<object> {
-    const payload = { credDef, user };
-    
+  createCredentialDefinition(credDef: CreateCredentialDefinitionDto, user: IUserRequestInterface): Promise<ICredDef> {
+    const payload = { credDef, user };   
     return this.sendNatsMessage(this.credDefServiceProxy, 'create-credential-definition', payload);
   }
 
-  getCredentialDefinitionById(credentialDefinitionId: string, orgId: string): Promise<{ response: object }> {
+  getCredentialDefinitionById(credentialDefinitionId: string, orgId: string): Promise<object> {
     const payload = { credentialDefinitionId, orgId };
-    return this.sendNats(this.credDefServiceProxy, 'get-credential-definition-by-id', payload);
+    return this.sendNatsMessage(this.credDefServiceProxy, 'get-credential-definition-by-id', payload);
   }
 
-  getAllCredDefs(credDefSearchCriteria: GetAllCredDefsDto, user: IUserRequestInterface, orgId: string): Promise<{ response: object }> {
+  getAllCredDefs(credDefSearchCriteria: GetAllCredDefsDto, user: IUserRequestInterface, orgId: string): Promise<ICredDefData> {
     const payload = { credDefSearchCriteria, user, orgId };
-    return this.sendNats(this.credDefServiceProxy, 'get-all-credential-definitions', payload);
+    return this.sendNatsMessage(this.credDefServiceProxy, 'get-all-credential-definitions', payload);
   }
 
   getCredentialDefinitionBySchemaId(schemaId: string): Promise<ICredDefs> {
@@ -36,8 +36,8 @@ export class CredentialDefinitionService extends BaseService {
     return this.sendNatsMessage(this.credDefServiceProxy, 'get-all-credential-definitions-by-schema-id', payload);
   }
 
-  getAllCredDefAndSchemaForBulkOperation(orgId:string): Promise<{ response: object }> {
+  getAllCredDefAndSchemaForBulkOperation(orgId:string): Promise<ICredentialDefinition> {
     const payload = { orgId };
-    return this.sendNats(this.credDefServiceProxy, 'get-all-schema-cred-defs-for-bulk-operation', payload);
+    return this.sendNatsMessage(this.credDefServiceProxy, 'get-all-schema-cred-defs-for-bulk-operation', payload);
   }
 }

--- a/apps/api-gateway/src/credential-definition/credential-definition.service.ts
+++ b/apps/api-gateway/src/credential-definition/credential-definition.service.ts
@@ -4,6 +4,7 @@ import { CreateCredentialDefinitionDto } from './dto/create-cred-defs.dto';
 import { BaseService } from '../../../../libs/service/base.service';
 import { IUserRequestInterface } from '../interfaces/IUserRequestInterface';
 import { GetAllCredDefsDto } from '../dtos/get-cred-defs.dto';
+import { ICredDefs } from './interfaces';
 
 @Injectable()
 export class CredentialDefinitionService extends BaseService {
@@ -30,9 +31,9 @@ export class CredentialDefinitionService extends BaseService {
     return this.sendNats(this.credDefServiceProxy, 'get-all-credential-definitions', payload);
   }
 
-  getCredentialDefinitionBySchemaId(schemaId: string): Promise<{ response: object }> {
+  getCredentialDefinitionBySchemaId(schemaId: string): Promise<ICredDefs> {
     const payload = { schemaId };
-    return this.sendNats(this.credDefServiceProxy, 'get-all-credential-definitions-by-schema-id', payload);
+    return this.sendNatsMessage(this.credDefServiceProxy, 'get-all-credential-definitions-by-schema-id', payload);
   }
 
   getAllCredDefAndSchemaForBulkOperation(orgId:string): Promise<{ response: object }> {

--- a/apps/api-gateway/src/credential-definition/dto/create-cred-defs.dto.ts
+++ b/apps/api-gateway/src/credential-definition/dto/create-cred-defs.dto.ts
@@ -5,14 +5,17 @@ import { ApiProperty } from '@nestjs/swagger';
 export class CreateCredentialDefinitionDto {
 
     @ApiProperty({ 'example': 'default' })
+    @IsDefined({ message: 'Tag is required.' })
     @IsNotEmpty({ message: 'Please provide a tag' })
     @IsString({ message: 'Tag id should be string' })
     tag: string;
 
     @ApiProperty({ 'example': 'WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0' })
+    @IsDefined({ message: 'schemaLedgerId is required.' })
     @IsNotEmpty({ message: 'Please provide a schema id' })
     @IsString({ message: 'Schema id should be string' })
     schemaLedgerId: string;
+
     orgId: string;
 
     @ApiProperty({ required: false })

--- a/apps/api-gateway/src/credential-definition/interfaces/index.ts
+++ b/apps/api-gateway/src/credential-definition/interfaces/index.ts
@@ -39,3 +39,17 @@ export interface IOrgAgentInterface {
   agentsTypeId: string;
   orgId: string;
 }
+
+export interface ICredDefs {
+  id: string;
+  createDateTime: string;
+  createdBy: string;
+  lastChangedDateTime: string;
+  lastChangedBy: string;
+  credentialDefinitionId: string;
+  tag: string;
+  schemaLedgerId: string;
+  schemaId: string;
+  revocable: boolean;
+  orgId: string;
+}

--- a/apps/api-gateway/src/credential-definition/interfaces/index.ts
+++ b/apps/api-gateway/src/credential-definition/interfaces/index.ts
@@ -39,17 +39,28 @@ export interface IOrgAgentInterface {
   agentsTypeId: string;
   orgId: string;
 }
-
-export interface ICredDefs {
+export interface ICredDef {
   id: string;
   createDateTime: string;
   createdBy: string;
-  lastChangedDateTime: string;
-  lastChangedBy: string;
   credentialDefinitionId: string;
   tag: string;
   schemaLedgerId: string;
   schemaId: string;
   revocable: boolean;
   orgId: string;
+}
+
+export interface ICredDefs extends ICredDef{
+  lastChangedDateTime: string;
+  lastChangedBy: string;
+}
+
+export interface ICredentialDefinition {
+  credentialDefinitionId: string;
+  schemaCredDefName: string;
+  schemaName: string;
+  schemaVersion: string;
+  schemaAttributes: string;
+  credentialDefinition: string;
 }

--- a/apps/ledger/src/credential-definition/credential-definition.controller.ts
+++ b/apps/ledger/src/credential-definition/credential-definition.controller.ts
@@ -8,7 +8,7 @@ import {  GetAllCredDefsPayload, GetCredDefBySchemaId } from './interfaces/creat
 import { CreateCredDefPayload, GetCredDefPayload } from './interfaces/create-credential-definition.interface';
 import { credential_definition } from '@prisma/client';
 import { CredDefSchema } from './interfaces/credential-definition.interface';
-
+import { ICredDefDetails } from '@credebl/common/interfaces/cred-def.interface';
 @Controller('credential-definitions')
 export class CredentialDefinitionController {
     private logger = new Logger();
@@ -26,24 +26,7 @@ export class CredentialDefinitionController {
     }
 
     @MessagePattern({ cmd: 'get-all-credential-definitions' })
-    async getAllCredDefs(payload: GetAllCredDefsPayload): Promise<{
-        totalItems: number;
-        hasNextPage: boolean;
-        hasPreviousPage: boolean;
-        nextPage: number;
-        previousPage: number;
-        lastPage: number;
-        data: {
-            createDateTime: Date;
-            createdBy: string;
-            credentialDefinitionId: string;
-            tag: string;
-            schemaLedgerId: string;
-            schemaId: string;
-            orgId: string;
-            revocable: boolean;
-        }[]
-    }> {
+    async getAllCredDefs(payload: GetAllCredDefsPayload): Promise<ICredDefDetails> {
         return this.credDefService.getAllCredDefs(payload);
     }
 

--- a/apps/ledger/src/credential-definition/credential-definition.service.ts
+++ b/apps/ledger/src/credential-definition/credential-definition.service.ts
@@ -14,11 +14,10 @@ import { credential_definition } from '@prisma/client';
 import { ResponseMessages } from '@credebl/common/response-messages';
 import { CreateCredDefAgentRedirection, CredDefSchema, GetCredDefAgentRedirection } from './interfaces/credential-definition.interface';
 import { map } from 'rxjs/operators';
-import { OrgAgentType } from '@credebl/enum/enum';
+import { OrgAgentType, SortValue } from '@credebl/enum/enum';
 import { Cache } from 'cache-manager';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ICredDefDetails } from '@credebl/common/interfaces/cred-def.interface';
-import { sortValue } from 'apps/api-gateway/src/enum';
 @Injectable()
 export class CredentialDefinitionService extends BaseService {
     constructor(
@@ -290,7 +289,7 @@ export class CredentialDefinitionService extends BaseService {
         try {
             const payload = {
                 orgId,
-                sortValue: sortValue.ASC,
+                sortValue: SortValue.ASC,
                 credDefSortBy: 'id'
             };
 

--- a/apps/ledger/src/credential-definition/credential-definition.service.ts
+++ b/apps/ledger/src/credential-definition/credential-definition.service.ts
@@ -17,6 +17,8 @@ import { map } from 'rxjs/operators';
 import { OrgAgentType } from '@credebl/enum/enum';
 import { Cache } from 'cache-manager';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ICredDefDetails } from '@credebl/common/interfaces/cred-def.interface';
+import { sortValue } from 'apps/api-gateway/src/enum';
 @Injectable()
 export class CredentialDefinitionService extends BaseService {
     constructor(
@@ -201,6 +203,7 @@ export class CredentialDefinitionService extends BaseService {
             if (credDefResponse.response.resolutionMetadata.error) {
                 throw new NotFoundException(ResponseMessages.credentialDefinition.error.credDefIdNotFound);
             }
+
             return credDefResponse;
         } catch (error) {
             this.logger.error(`Error retrieving credential definition with id ${payload.credentialDefinitionId}`);
@@ -219,6 +222,7 @@ export class CredentialDefinitionService extends BaseService {
     async _getCredentialDefinitionById(payload: GetCredDefAgentRedirection): Promise<{
         response: string;
     }> {
+        
         try {
             const pattern = {
                 cmd: 'agent-get-credential-definition'
@@ -246,24 +250,7 @@ export class CredentialDefinitionService extends BaseService {
         }
     }
 
-    async getAllCredDefs(payload: GetAllCredDefsPayload): Promise<{
-        totalItems: number;
-        hasNextPage: boolean;
-        hasPreviousPage: boolean;
-        nextPage: number;
-        previousPage: number;
-        lastPage: number;
-        data: {
-            createDateTime: Date;
-            createdBy: string;
-            credentialDefinitionId: string;
-            tag: string;
-            schemaLedgerId: string;
-            schemaId: string;
-            orgId: string;
-            revocable: boolean;
-        }[]
-    }> {
+    async getAllCredDefs(payload: GetAllCredDefsPayload): Promise<ICredDefDetails> {
         try {
             const { credDefSearchCriteria, orgId } = payload;
             const response = await this.credentialDefinitionRepository.getAllCredDefs(credDefSearchCriteria, orgId);
@@ -303,7 +290,7 @@ export class CredentialDefinitionService extends BaseService {
         try {
             const payload = {
                 orgId,
-                sortValue: 'ASC',
+                sortValue: sortValue.ASC,
                 credDefSortBy: 'id'
             };
 

--- a/apps/ledger/src/credential-definition/repositories/credential-definition.repository.ts
+++ b/apps/ledger/src/credential-definition/repositories/credential-definition.repository.ts
@@ -5,6 +5,8 @@ import { credential_definition, org_agents, org_agents_type, organisation, schem
 import { Injectable, Logger } from '@nestjs/common';
 import { ResponseMessages } from '@credebl/common/response-messages';
 import { BulkCredDefSchema, CredDefSchema } from '../interfaces/credential-definition.interface';
+import { ICredDefData } from '@credebl/common/interfaces/cred-def.interface';
+import { SortValue, sortValue } from 'apps/api-gateway/src/enum';
 
 @Injectable()
 export class CredentialDefinitionRepository {
@@ -64,16 +66,7 @@ export class CredentialDefinitionRepository {
         }
     }
 
-    async getAllCredDefs(credDefSearchCriteria: GetAllCredDefsDto, orgId: string): Promise<{
-        createDateTime: Date;
-        createdBy: string;
-        credentialDefinitionId: string;
-        tag: string;
-        schemaLedgerId: string;
-        schemaId: string;
-        orgId: string;
-        revocable: boolean;
-    }[]> {
+    async getAllCredDefs(credDefSearchCriteria: GetAllCredDefsDto, orgId: string): Promise<ICredDefData[]> {
         try {
             const credDefResult = await this.prisma.credential_definition.findMany({
                 where: {
@@ -95,7 +88,7 @@ export class CredentialDefinitionRepository {
                     revocable: true
                 },
                 orderBy: {
-                    [credDefSearchCriteria.sorting]: 'desc' === credDefSearchCriteria.sortByValue ? 'desc' : 'asc'
+                    [credDefSearchCriteria.sorting]: sortValue.DESC === credDefSearchCriteria.sortByValue ? sortValue.DESC : sortValue.ASC
                 },
                 take: credDefSearchCriteria.pageSize,
                 skip: (credDefSearchCriteria.pageNumber - 1) * credDefSearchCriteria.pageSize
@@ -186,7 +179,7 @@ export class CredentialDefinitionRepository {
                     schemaLedgerId: true
                 },
                 orderBy: {
-                    [credDefSortBy]: 'desc' === sortValue ? 'desc' : 'asc'
+                    [credDefSortBy]: SortValue.DESC === sortValue ? SortValue.DESC : SortValue.ASC
                 }
             });
 
@@ -206,7 +199,6 @@ export class CredentialDefinitionRepository {
                     attributes: true
                 }
             });
-
 
             // Match Credential Definitions with Schemas and map to CredDefSchema
             const matchingSchemas = credentialDefinitions.map((credDef) => {

--- a/apps/ledger/src/credential-definition/repositories/credential-definition.repository.ts
+++ b/apps/ledger/src/credential-definition/repositories/credential-definition.repository.ts
@@ -6,7 +6,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ResponseMessages } from '@credebl/common/response-messages';
 import { BulkCredDefSchema, CredDefSchema } from '../interfaces/credential-definition.interface';
 import { ICredDefData } from '@credebl/common/interfaces/cred-def.interface';
-import { SortValue, sortValue } from 'apps/api-gateway/src/enum';
+import { SortValue } from '@credebl/enum/enum';
 
 @Injectable()
 export class CredentialDefinitionRepository {
@@ -88,7 +88,7 @@ export class CredentialDefinitionRepository {
                     revocable: true
                 },
                 orderBy: {
-                    [credDefSearchCriteria.sorting]: sortValue.DESC === credDefSearchCriteria.sortByValue ? sortValue.DESC : sortValue.ASC
+                    [credDefSearchCriteria.sorting]: SortValue.DESC === credDefSearchCriteria.sortByValue ? SortValue.DESC : SortValue.ASC
                 },
                 take: credDefSearchCriteria.pageSize,
                 skip: (credDefSearchCriteria.pageNumber - 1) * credDefSearchCriteria.pageSize

--- a/libs/common/src/interfaces/cred-def.interface.ts
+++ b/libs/common/src/interfaces/cred-def.interface.ts
@@ -1,0 +1,20 @@
+export interface ICredDefDetails {
+    totalItems: number;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    nextPage: number;
+    previousPage: number;
+    lastPage: number;
+    data: ICredDefData[];
+}
+
+export interface ICredDefData {
+    createDateTime: Date;
+    createdBy: string;
+    credentialDefinitionId: string;
+    tag: string;
+    schemaLedgerId: string;
+    schemaId: string;
+    orgId: string;
+    revocable: boolean;
+}


### PR DESCRIPTION
### What?
- Modify GET API of `/orgs/{orgId}/cred-defs/{credDefId}` (get an existing cred def by id).
- Modify GET API of `/verification/cred-defs/{schemaId}` (get an existing cred def by schema id).
- Modify GET API of `/orgs/{orgId}/cred-defs` (get all cred-defs of provided org id with pagination).
- Modify GET API of `/orgs/{orgId}/bulk/cred-defs` (fetch all cred-defs for bulk operation).
- Modify  POST API of `/orgs/{orgId}/cred-defs` (create and sends a cred-def to the ledger).

1.Checked validations on payload.
2.Refactor response
3.Ensured consistency of API status codes.
4.Modified the NATS function.

### Why?
- The implementation of a well-defined interface enhances code readability and makes the structure of the API response more explicit.
- Ensuring consistent API status codes improves communication between different components of the system and enhances overall reliability.

### How?
Replaced the return type with a well-defined interface to enhance code clarity.
Checked and standardized API status codes to ensure a uniform response.
Modified the NATS function to accommodate the adjustments made in the API.