### PR TITLE
fix: wallet creation DTO issue

### DIFF
--- a/apps/api-gateway/src/agent-service/agent-service.controller.ts
+++ b/apps/api-gateway/src/agent-service/agent-service.controller.ts
@@ -32,9 +32,9 @@ import { CustomExceptionFilter } from 'apps/api-gateway/common/exception-handler
 import { Roles } from '../authz/decorators/roles.decorator';
 import { OrgRoles } from 'libs/org-roles/enums';
 import { OrgRolesGuard } from '../authz/guards/org-roles.guard';
-import { CreateDidDto } from './dto/create-did.dto';
 import { validateDid } from '@credebl/common/did.validator';
 import { CreateWalletDto } from './dto/create-wallet.dto';
+import { CreateNewDidDto } from './dto/create-new-did.dto';
 
 const seedLength = 32;
 
@@ -232,7 +232,7 @@ export class AgentController {
    @ApiResponse({ status: HttpStatus.CREATED, description: 'Success', type: ApiResponseDto })
    async createDid(
      @Param('orgId') orgId: string,
-     @Body() createDidDto: CreateDidDto,
+     @Body() createDidDto: CreateNewDidDto,
      @User() user: user,
      @Res() res: Response
    ): Promise<Response> {

--- a/apps/api-gateway/src/agent-service/dto/create-did.dto.ts
+++ b/apps/api-gateway/src/agent-service/dto/create-did.dto.ts
@@ -1,7 +1,7 @@
 import { trim } from '@credebl/common/cast.helper';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { MaxLength, IsString, Matches, IsNotEmpty, IsOptional, IsBoolean } from 'class-validator';
+import { MaxLength, IsString, Matches, IsNotEmpty, IsOptional } from 'class-validator';
 
 export class CreateDidDto {
 
@@ -75,9 +75,4 @@ export class CreateDidDto {
     @Transform(({ value }) => trim(value))
     @IsString({ message: 'endorser did must be in string format.' })
     endorserDid?: string;
-
-    @ApiProperty({example: false})
-    @ApiPropertyOptional()
-    @IsBoolean({ message: 'isPrimaryDid did must be true or false.' })
-    isPrimaryDid: boolean = false;
 }

--- a/apps/api-gateway/src/agent-service/dto/create-new-did.dto.ts
+++ b/apps/api-gateway/src/agent-service/dto/create-new-did.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+import { CreateDidDto } from './create-did.dto';
+export class CreateNewDidDto extends CreateDidDto {
+    @ApiProperty({example: false})
+    @ApiPropertyOptional()
+    @IsBoolean({ message: 'isPrimaryDid did must be true or false.' })
+    isPrimaryDid: boolean = false; 
+}


### PR DESCRIPTION
#### What ####
- `isPrimaryDid` parameter was implemented in `createDidDto`
#### How ####
- Created one new DTO for `isPrimaryDid` and extended the property of  `createDidDto`