### PR TITLE
Update presentation definition payload of W3C request

### DIFF
--- a/apps/api-gateway/src/verification/dto/request-proof.dto.ts
+++ b/apps/api-gateway/src/verification/dto/request-proof.dto.ts
@@ -219,13 +219,17 @@ export class ProofRequestPresentationDefinition {
     @IsString()
     @IsNotEmpty({ message: 'id is required.' })
     id: string;
+
+    @IsString()
+    @IsOptional()
+    name: string;
+
     @ApiProperty({type: () =>  [InputDescriptors]})
     @IsNotEmpty({ message: 'inputDescriptors is required.' })
     @IsArray({ message: 'inputDescriptors must be an array' })
     @IsObject({ each: true })
     @Type(() => InputDescriptors)
     @ValidateNested()
-    
     // eslint-disable-next-line camelcase
     input_descriptors:InputDescriptors[];
 }


### PR DESCRIPTION
##What
Added a missing attribute `name` in presentationDefinition payload. This is a shared attributes between the verifier and prover addition to the requested data attributes.

##Why
To be aligned with the standard specification.