### PR TITLE
fix: Invalid nested response

### DIFF
--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -252,7 +252,7 @@ export class IssuanceService {
         const url: string = await this.storeIssuanceObjectReturnUrl(invitationUrl);
         credentialCreateOfferDetails.response['invitationUrl'] = url;
       }
-      return credentialCreateOfferDetails;
+      return credentialCreateOfferDetails.response;
     } catch (error) {
       this.logger.error(`[storeIssuanceObjectReturnUrl] - error in create credentials : ${JSON.stringify(error)}`);
 


### PR DESCRIPTION
## What:
- Fixes invalid response inside response for oob issuance

## Why:
- Previous response included response inside a response object

Fixes: [#406](https://github.com/credebl/automation-test-suite/issues/406)