### PR TITLE
feat: limit 10 organizations per user

### DIFF
--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -632,7 +632,7 @@ export class OrganizationRepository {
     }
   }
 
-  async countUserOrganizations(userId: string): Promise<number> {
+  async userOrganizationCount(userId: string): Promise<number> {
     const getOrgCount = await this.prisma.organisation.count({
       where: {
         userOrgRoles: {

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -633,12 +633,12 @@ export class OrganizationRepository {
   }
 
   async countUserOrganizations(userId: string): Promise<number> {
-    const count = await this.prisma.organisation.count({
+    const getOrgCount = await this.prisma.organisation.count({
       where: {
         createdBy: userId
       }
     });
-    return count;
+    return getOrgCount;
   }
   /**
   *

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -632,6 +632,14 @@ export class OrganizationRepository {
     }
   }
 
+  async countUserOrganizations(userId: string): Promise<number> {
+    const count = await this.prisma.organisation.count({
+      where: {
+        createdBy: userId
+      }
+    });
+    return count;
+  }
   /**
   *
   * @param name

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -635,7 +635,9 @@ export class OrganizationRepository {
   async countUserOrganizations(userId: string): Promise<number> {
     const getOrgCount = await this.prisma.organisation.count({
       where: {
-        createdBy: userId
+        userOrgRoles: {
+          some: { userId }
+        }
       }
     });
     return getOrgCount;

--- a/apps/organization/src/organization.controller.ts
+++ b/apps/organization/src/organization.controller.ts
@@ -82,6 +82,20 @@ export class OrganizationController {
     const { userId, pageNumber, pageSize, search, role } = payload;
     return this.organizationService.getOrganizations(userId, pageNumber, pageSize, search, role);
   }
+  /**
+   * Description: get organization count
+   * @param
+   * @returns Get created organization details
+   */
+  @MessagePattern({ cmd: 'get-count-organizations' })
+  async countTotalOrgs(
+    @Body() payload: { userId: string}
+  ): Promise<number> {
+    
+    const { userId } = payload;
+    
+    return this.organizationService.countTotalOrgs(userId);
+  }
 
   /**
    * @returns Get public organization details

--- a/apps/organization/src/organization.controller.ts
+++ b/apps/organization/src/organization.controller.ts
@@ -87,7 +87,7 @@ export class OrganizationController {
    * @param
    * @returns Get created organization details
    */
-  @MessagePattern({ cmd: 'get-count-organizations' })
+  @MessagePattern({ cmd: 'get-organizations-count' })
   async countTotalOrgs(
     @Body() payload: { userId: string}
   ): Promise<number> {

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -75,6 +75,12 @@ export class OrganizationService {
     keycloakUserId: string
   ): Promise<organisation> {
     try {
+      const userOrgCount = await this.organizationRepository.countUserOrganizations(userId); 
+  
+      if (userOrgCount >= toNumber(`${process.env.MAX_ORG_LIMIT}`)) {
+       throw new BadRequestException(ResponseMessages.organisation.error.MaximumOrgsLimit);
+      }
+
       const organizationExist = await this.organizationRepository.checkOrganizationNameExist(createOrgDto.name);
 
       if (organizationExist) {
@@ -100,11 +106,6 @@ export class OrganizationService {
         createOrgDto.logo = '';
       }
 
-      const userOrgCount = await this.organizationRepository.countUserOrganizations(userId);
-
-    if (userOrgCount >= toNumber(`${process.env.MAX_ORG_LIMIT}`)) {
-      throw new BadRequestException(ResponseMessages.organisation.error.MaximumOrgsLimit);
-    }
       
       const organizationDetails = await this.organizationRepository.createOrganization(createOrgDto);
 

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -75,7 +75,7 @@ export class OrganizationService {
     keycloakUserId: string
   ): Promise<organisation> {
     try {
-      const userOrgCount = await this.organizationRepository.countUserOrganizations(userId); 
+      const userOrgCount = await this.organizationRepository.userOrganizationCount(userId); 
   
       if (userOrgCount >= toNumber(`${process.env.MAX_ORG_LIMIT}`)) {
        throw new BadRequestException(ResponseMessages.organisation.error.MaximumOrgsLimit);
@@ -531,7 +531,7 @@ export class OrganizationService {
    ): Promise<number> {
     try {
       
-      const getOrgs = await this.organizationRepository.countUserOrganizations(userId);
+      const getOrgs = await this.organizationRepository.userOrganizationCount(userId);
       return getOrgs;
     } catch (error) {
       this.logger.error(`In fetch getOrganizations : ${JSON.stringify(error)}`);
@@ -1075,7 +1075,7 @@ export class OrganizationService {
       const invitation = await this.organizationRepository.getInvitationById(String(invitationId));
 
       if (Invitation.ACCEPTED === payload.status) {
-        const userOrgCount = await this.organizationRepository.countUserOrganizations(userId);
+        const userOrgCount = await this.organizationRepository.userOrganizationCount(userId);
 
         if (userOrgCount >= toNumber(`${process.env.MAX_ORG_LIMIT}`)) {
           throw new BadRequestException(ResponseMessages.organisation.error.MaximumOrgsLimit);

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -1073,7 +1073,7 @@ export class OrganizationService {
       const { orgId, status, invitationId, userId, keycloakUserId, email } = payload;
       const invitation = await this.organizationRepository.getInvitationById(String(invitationId));
 
-      if ('accepted' === payload.status) {
+      if (Invitation.ACCEPTED === payload.status) {
         const userOrgCount = await this.organizationRepository.countUserOrganizations(userId);
 
         if (userOrgCount >= toNumber(`${process.env.MAX_ORG_LIMIT}`)) {

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -60,6 +60,7 @@ import { IUsersActivity } from 'libs/user-activity/interface';
 import { ISendVerificationEmail, ISignInUser, IVerifyUserEmail, IUserInvitations, IResetPasswordResponse } from '@credebl/common/interfaces/user.interface';
 import { AddPasskeyDetailsDto } from 'apps/api-gateway/src/user/dto/add-user.dto';
 import { URLUserResetPasswordTemplate } from '../templates/reset-password-template';
+import { toNumber } from '@credebl/common/cast.helper';
 
 @Injectable()
 export class UserService {
@@ -823,11 +824,40 @@ export class UserService {
   async acceptRejectInvitations(acceptRejectInvitation: AcceptRejectInvitationDto, userId: string): Promise<IUserInvitations> {
     try {
       const userData = await this.userRepository.getUserById(userId);
+     
+      if ('accepted' === acceptRejectInvitation.status) {
+        const payload = {userId};
+        const TotalOrgs = await this._getTotalOrgCount(payload);
+  
+        if (TotalOrgs >= toNumber(`${process.env.MAX_ORG_LIMIT}`)) {
+        throw new BadRequestException(ResponseMessages.user.error.maximumOrgsLimit);
+         }
+      }
       return this.fetchInvitationsStatus(acceptRejectInvitation, userData.keycloakUserId, userData.email, userId);
     } catch (error) {
       this.logger.error(`acceptRejectInvitations: ${error}`);
       throw new RpcException(error.response ? error.response : error);
     }
+  }
+
+  async  _getTotalOrgCount(payload): Promise<number> {
+    const pattern = { cmd: 'get-count-organizations' };
+
+    const w3cSchemaData = await this.userServiceProxy
+      .send(pattern, payload)
+      .toPromise()
+      .catch((error) => {
+        this.logger.error(`catch: ${JSON.stringify(error)}`);
+        throw new HttpException(
+          {
+            status: error.status,
+            error: error.message
+          },
+          error.status
+        );
+      });
+
+    return w3cSchemaData;
   }
 
   async shareUserCertificate(shareUserCertificate: IShareUserCertificate): Promise<string> {

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -47,7 +47,7 @@ import { UserActivityService } from '@credebl/user-activity';
 import { SupabaseService } from '@credebl/supabase';
 import { UserDevicesRepository } from '../repositories/user-device.repository';
 import { v4 as uuidv4 } from 'uuid';
-import { EcosystemConfigSettings, UserCertificateId } from '@credebl/enum/enum';
+import { EcosystemConfigSettings, Invitation, UserCertificateId } from '@credebl/enum/enum';
 import { WinnerTemplate } from '../templates/winner-template';
 import { ParticipantTemplate } from '../templates/participant-template';
 import { ArbiterTemplate } from '../templates/arbiter-template';
@@ -825,12 +825,12 @@ export class UserService {
     try {
       const userData = await this.userRepository.getUserById(userId);
      
-      if ('accepted' === acceptRejectInvitation.status) {
+      if (Invitation.ACCEPTED === acceptRejectInvitation.status) {
         const payload = {userId};
         const TotalOrgs = await this._getTotalOrgCount(payload);
   
         if (TotalOrgs >= toNumber(`${process.env.MAX_ORG_LIMIT}`)) {
-        throw new BadRequestException(ResponseMessages.user.error.maximumOrgsLimit);
+        throw new BadRequestException(ResponseMessages.user.error.userOrgsLimit);
          }
       }
       return this.fetchInvitationsStatus(acceptRejectInvitation, userData.keycloakUserId, userData.email, userId);

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -843,7 +843,7 @@ export class UserService {
   async  _getTotalOrgCount(payload): Promise<number> {
     const pattern = { cmd: 'get-organizations-count' };
 
-    const w3cSchemaData = await this.userServiceProxy
+    const getOrganizationCount = await this.userServiceProxy
       .send(pattern, payload)
       .toPromise()
       .catch((error) => {
@@ -857,7 +857,7 @@ export class UserService {
         );
       });
 
-    return w3cSchemaData;
+    return getOrganizationCount;
   }
 
   async shareUserCertificate(shareUserCertificate: IShareUserCertificate): Promise<string> {

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -841,7 +841,7 @@ export class UserService {
   }
 
   async  _getTotalOrgCount(payload): Promise<number> {
-    const pattern = { cmd: 'get-count-organizations' };
+    const pattern = { cmd: 'get-organizations-count' };
 
     const w3cSchemaData = await this.userServiceProxy
       .send(pattern, payload)

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -62,7 +62,8 @@ export const ResponseMessages = {
             resetPasswordLink: 'Unable to create reset password token',
             invalidResetLink: 'Invalid or expired reset password link',
             invalidAccessToken: 'Authentication failed',
-            invalidRefreshToken: 'Invalid refreshToken provided'
+            invalidRefreshToken: 'Invalid refreshToken provided',
+            maximumOrgsLimit:'Limit reached you can be associated with only 10 orgs'
         }
     },
     organisation: {
@@ -117,7 +118,8 @@ export const ResponseMessages = {
             orgDoesNotMatch: 'Organization does not match',
             invalidClient: 'Invalid client credentials',
             primaryDid: 'This DID is already set to primary DID',
-            didNotFound: 'DID does not exist in organiation'
+            didNotFound: 'DID does not exist in organiation',
+            MaximumOrgsLimit:'Limit reached: you can only create maximum 10 organizations'
         }
     },
 

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -63,7 +63,7 @@ export const ResponseMessages = {
             invalidResetLink: 'Invalid or expired reset password link',
             invalidAccessToken: 'Authentication failed',
             invalidRefreshToken: 'Invalid refreshToken provided',
-            userOrgsLimit:'Limit reached you can be associated with only 10 organizations'
+            userOrgsLimit:'Limit reached: You can be associated with or create maximum 10 organizations.'
         }
     },
     organisation: {
@@ -119,7 +119,7 @@ export const ResponseMessages = {
             invalidClient: 'Invalid client credentials',
             primaryDid: 'This DID is already set to primary DID',
             didNotFound: 'DID does not exist in organiation',
-            MaximumOrgsLimit:'Limit reached: you can only create maximum 10 organizations'
+            MaximumOrgsLimit:'Limit reached: You can be associated with or create maximum 10 organizations.'
         }
     },
 

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -63,7 +63,7 @@ export const ResponseMessages = {
             invalidResetLink: 'Invalid or expired reset password link',
             invalidAccessToken: 'Authentication failed',
             invalidRefreshToken: 'Invalid refreshToken provided',
-            maximumOrgsLimit:'Limit reached you can be associated with only 10 orgs'
+            userOrgsLimit:'Limit reached you can be associated with only 10 organizations'
         }
     },
     organisation: {


### PR DESCRIPTION
### What 

- Changes in POST `/orgs` Create a new Organization API. Implemented logic to restricted user to create more than 10 organizations.
- Changes in POST `/users/org-invitations/{invitationId}` accept/reject organization invitation API. Implemented logic to restrict user for accepting organization invitation if user is already associated with 10 organziations