### PR TITLE
fix: set primary DID for new DID

### DIFF
--- a/apps/agent-service/src/agent-service.service.ts
+++ b/apps/agent-service/src/agent-service.service.ts
@@ -930,7 +930,6 @@ export class AgentServiceService {
    */
   async createDid(createDidPayload: IDidCreate, orgId: string, user: IUserRequestInterface): Promise<object> {
     try {
-      const { isPrimaryDid } = createDidPayload;
       const agentDetails = await this.agentServiceRepository.getOrgAgentDetails(orgId);
       if (createDidPayload.method === DidMethod.POLYGON) {
         createDidPayload.endpoint = agentDetails.agentEndPoint;
@@ -944,18 +943,37 @@ export class AgentServiceService {
         url = `${agentDetails.agentEndPoint}${CommonConstants.URL_SHAGENT_CREATE_DID}${agentDetails.tenantId}`;
       }
 
-      delete createDidPayload.isPrimaryDid;
+      const { isPrimaryDid, ...payload } = createDidPayload;
 
-      const didDetails = await this.commonService.httpPost(url, createDidPayload, {
+      const getDidByOrg = await this.agentServiceRepository.getOrgDid(orgId);
+
+      
+      const didDetails = await this.commonService.httpPost(url, payload, {
         headers: { authorization: getApiKey }
       });
-
+      
       if (!didDetails || Object.keys(didDetails).length === 0) {
         throw new InternalServerErrorException(ResponseMessages.agent.error.createDid, {
           cause: new Error(),
           description: ResponseMessages.errorMessages.serverError
         });
       }
+      
+      
+      const didExist = getDidByOrg.some((orgDidExist) => orgDidExist.did === didDetails.did);
+      if (didExist) {
+        throw new ConflictException(ResponseMessages.agent.error.didAlreadyExist, {
+          cause: new Error(),
+          description: ResponseMessages.errorMessages.serverError
+        });
+      }
+      
+      if (isPrimaryDid) {
+        getDidByOrg.map(async () => {
+          await this.agentServiceRepository.updateIsPrimaryDid(orgId, false);
+        });
+      }
+      
       const createdDidDetails = {
         orgId,
         did: didDetails.did,
@@ -964,6 +982,7 @@ export class AgentServiceService {
         orgAgentId: agentDetails.id,
         userId: user.id
       };
+
       const storeDidDetails = await this.agentServiceRepository.storeDidDetails(createdDidDetails);
 
       if (!storeDidDetails) {

--- a/apps/agent-service/src/interface/agent-service.interface.ts
+++ b/apps/agent-service/src/interface/agent-service.interface.ts
@@ -1,4 +1,5 @@
 import { AgentSpinUpStatus } from '@credebl/enum/enum';
+import { Prisma } from '@prisma/client';
 import { UserRoleOrgPermsDto } from 'apps/api-gateway/src/dtos/user-role-org-perms.dto';
 
 export interface IAgentSpinupDto {
@@ -622,4 +623,17 @@ export interface LedgerNameSpace {
   nymTxnEndpoint: string;
   indyNamespace: string;
   networkUrl: string;
+}
+
+export interface OrgDid {
+  id: string;
+  createDateTime: Date;
+  createdBy: string;
+  lastChangedDateTime: Date;
+  lastChangedBy: string;
+  orgId: string;
+  isPrimaryDid: boolean;
+  did: string;
+  didDocument: Prisma.JsonValue;
+  orgAgentId: string;
 }

--- a/apps/agent-service/src/repositories/agent-service.repository.ts
+++ b/apps/agent-service/src/repositories/agent-service.repository.ts
@@ -1,8 +1,8 @@
 import { PrismaService } from '@credebl/prisma-service';
 import { Injectable, Logger } from '@nestjs/common';
 // eslint-disable-next-line camelcase
-import { ledgerConfig, ledgers, org_agents, org_agents_type, org_dids, organisation, platform_config, user } from '@prisma/client';
-import { ICreateOrgAgent, IOrgAgent, IOrgAgentsResponse, IOrgLedgers, IStoreAgent, IStoreDidDetails, IStoreOrgAgentDetails, LedgerNameSpace } from '../interface/agent-service.interface';
+import { Prisma, ledgerConfig, ledgers, org_agents, org_agents_type, org_dids, organisation, platform_config, user } from '@prisma/client';
+import { ICreateOrgAgent, IOrgAgent, IOrgAgentsResponse, IOrgLedgers, IStoreAgent, IStoreDidDetails, IStoreOrgAgentDetails, LedgerNameSpace, OrgDid } from '../interface/agent-service.interface';
 import { AgentType } from '@credebl/enum/enum';
 
 @Injectable()
@@ -184,14 +184,14 @@ export class AgentServiceRepository {
      * @returns did details
      */
     // eslint-disable-next-line camelcase
-    async setPrimaryDid(isPrimaryDid:string, orgId:string): Promise<org_agents> {
+    async setPrimaryDid(orgDid: string, orgId: string): Promise<org_agents> {
         try {
           return await this.prisma.org_agents.update({
                  where: {
                     orgId
                  },
                 data: {
-                    orgDid: isPrimaryDid
+                    orgDid
                 }
             });
            
@@ -449,6 +449,37 @@ export class AgentServiceRepository {
 
     } catch (error) {
       this.logger.error(`[getLedgerByNameSpace] - get indy ledger: ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
+  async getOrgDid(orgId: string): Promise<OrgDid[]> {
+    try {
+      const orgDids = await this.prisma.org_dids.findMany({
+        where: {
+          orgId
+        }
+      });
+      return orgDids;
+    } catch (error) {
+      this.logger.error(`[getOrgDid] - get org DID: ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
+  async updateIsPrimaryDid(orgId: string, isPrimaryDid: boolean): Promise<Prisma.BatchPayload> {
+    try {
+      const updateOrgDid = await this.prisma.org_dids.updateMany({
+        where: {
+          orgId
+        },
+        data: {
+          isPrimaryDid
+        }
+      });
+      return updateOrgDid;
+    } catch (error) {
+      this.logger.error(`[getOrgDid] - get org DID: ${JSON.stringify(error)}`);
       throw error;
     }
   }

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -308,7 +308,7 @@ export class OrganizationController {
   */
 
    @Get('/:orgId/dids')
-   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER)
+   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.MEMBER)
    @ApiBearerAuth()
    @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
    @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -175,6 +175,7 @@ export class OrganizationService {
       if (orgAgentDetails.orgDid === did) {
         throw new ConflictException(ResponseMessages.organisation.error.primaryDid);
       }
+
       //check user DID exist in the organization's did list
       const organizationDidList = await this.organizationRepository.getAllOrganizationDid(orgId);
       const isDidMatch = organizationDidList.some(item => item.did === did);
@@ -194,17 +195,16 @@ export class OrganizationService {
         didDocument: didDetails.didDocument
       };
 
-      const setPrimaryDid = await this.organizationRepository.setOrgsPrimaryDid(primaryDidDetails);
-
+      
       const getExistingPrimaryDid = await this.organizationRepository.getPerviousPrimaryDid(orgId);
-
-
+      
      if (!getExistingPrimaryDid) {
        throw new NotFoundException(ResponseMessages.organisation.error.didNotFound);
      }
 
       const setPriviousDidFalse = await this.organizationRepository.setPreviousDidFlase(getExistingPrimaryDid.id);
       
+      const setPrimaryDid = await this.organizationRepository.setOrgsPrimaryDid(primaryDidDetails);
 
       await Promise.all([setPrimaryDid, getExistingPrimaryDid, setPriviousDidFalse]);
 

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -240,6 +240,7 @@ export const ResponseMessages = {
             invalidTenantIdIdFormat:'Invalid tenantId format',
             requiredTenantId:'Tenant Id is required',
             createDid:'Error while creating DID',
+            didAlreadyExist:'DID already exist',
             storeDid: 'Error while storing DID',
             agentSpinupError: 'Agent endpoint unreachable',
             agentEndpointRequired: 'Agent endpoint is required',


### PR DESCRIPTION
### What ###
This fix ensures that when a new DID (Decentralized Identifier) is created and marked as the primary DID, all other existing DIDs for that user are updated to not be the primary DID.

### Why ###
Ensuring only one DID is marked as primary per user.

### How ###

- Modify the code to set the primary DID correctly: Update the relevant part of the codebase where DIDs are created or updated to ensure only one DID is marked as primary.
- Update other DIDs: Implement logic to update all other DIDs to not be primary when a new primary DID is set.