### PR TITLE
feat: delete organization and wallet

### DIFF
--- a/apps/agent-provisioning/AFJ/scripts/start_agent.sh
+++ b/apps/agent-provisioning/AFJ/scripts/start_agent.sh
@@ -145,14 +145,14 @@ cat <<EOF >${CONFIG_FILE}
   "inboundTransport": [
     {
       "transport": "$PROTOCOL",
-      "port": "$INBOUND_PORT"
+      "port": $INBOUND_PORT
     }
   ],
   "outboundTransport": [
     "$PROTOCOL"
   ],
   "webhookUrl": "$WEBHOOK_HOST/wh/$AGENCY",
-  "adminPort": "$ADMIN_PORT",
+  "adminPort": $ADMIN_PORT,
   "tenancy": $TENANT,
   "schemaFileServerURL": "$SCHEMA_FILE_SERVER_URL"
 }

--- a/apps/agent-service/src/agent-service.controller.ts
+++ b/apps/agent-service/src/agent-service.controller.ts
@@ -242,8 +242,8 @@ export class AgentServiceController {
   }
 
   @MessagePattern({ cmd: 'delete-wallet' })
-  async deleteWallet(payload: { url, apiKey }): Promise<object> {
-    return this.agentServiceService.deleteWallet(payload.url, payload.apiKey);
+  async deleteWallet(payload: { orgId }): Promise<object> {
+    return this.agentServiceService.deleteWallet(payload.orgId);
   }
 
   @MessagePattern({ cmd: 'agent-receive-invitation-url' })

--- a/apps/agent-service/src/agent-service.service.ts
+++ b/apps/agent-service/src/agent-service.service.ts
@@ -121,7 +121,7 @@ export class AgentServiceService {
         this.agentServiceRepository.getPlatformConfigDetails(),
         this.agentServiceRepository.getAgentTypeDetails(),
         this.agentServiceRepository.getLedgerDetails(
-          agentSpinupDto.network ? agentSpinupDto.network : [Ledgers.Indicio_Demonet]
+          agentSpinupDto.ledgerName ? agentSpinupDto.ledgerName : [Ledgers.Indicio_Demonet]
         )
       ]);
 
@@ -1622,7 +1622,7 @@ export class AgentServiceService {
         const orgAgentTypeResult = await this.agentServiceRepository.getOrgAgentType(orgAgent.orgAgentTypeId);
 
         if (!orgAgentTypeResult) {
-            throw new InternalServerErrorException('Failed to get agent type information');
+            throw new NotFoundException(ResponseMessages.agent.error.orgAgentNotFound);
         }
 
         // Determine the URL based on the agent type
@@ -1636,11 +1636,10 @@ export class AgentServiceService {
         })
         .then(async (response) => response);
 
-        if (deleteWallet) {
-          await this.agentServiceRepository.deleteOrgAgentByOrg(orgId);
+        if (deleteWallet.status === 204) {
+          const deleteOrgAgent = await this.agentServiceRepository.deleteOrgAgentByOrg(orgId);
+          return deleteOrgAgent;
         }
-
-        return deleteWallet;
     } catch (error) {
         this.logger.error(`Error in delete wallet in agent service: ${JSON.stringify(error.message)}`);
         throw new RpcException(error.response ? error.response : error);

--- a/apps/agent-service/src/agent-service.service.ts
+++ b/apps/agent-service/src/agent-service.service.ts
@@ -1600,17 +1600,53 @@ export class AgentServiceService {
     }
   }
 
-  async deleteWallet(url: string, apiKey: string): Promise<object> {
+  async deleteWallet(orgId: string): Promise<object> {
     try {
-      const deleteWallet = await this.commonService
-        .httpDelete(url, { headers: { authorization: apiKey } })
+        // Retrieve the API key and agent information
+        const [getApiKeyResult, orgAgentResult] = await Promise.allSettled([
+            this.getOrgAgentApiKey(orgId),
+            this.agentServiceRepository.getAgentApiKey(orgId)
+        ]);
+
+        if (getApiKeyResult.status === 'rejected') {
+            throw new InternalServerErrorException(`Failed to get API key: ${getApiKeyResult.reason}`);
+        }
+
+        if (orgAgentResult.status === 'rejected') {
+            throw new InternalServerErrorException(`Failed to get agent information: ${orgAgentResult.reason}`);
+        }
+
+        const getApiKey = getApiKeyResult?.value;
+        const orgAgent = orgAgentResult?.value;
+
+        const orgAgentTypeResult = await this.agentServiceRepository.getOrgAgentType(orgAgent.orgAgentTypeId);
+
+        if (!orgAgentTypeResult) {
+            throw new InternalServerErrorException('Failed to get agent type information');
+        }
+
+        // Determine the URL based on the agent type
+        const url = orgAgentTypeResult.agent === OrgAgentType.SHARED
+            ? `${orgAgent.agentEndPoint}${CommonConstants.URL_SHAGENT_DELETE_SUB_WALLET}`.replace('#', orgAgent?.tenantId)
+            : `${orgAgent.agentEndPoint}${CommonConstants.URL_DELETE_WALLET}`;
+
+        // Make the HTTP DELETE request
+        const deleteWallet = await this.commonService.httpDelete(url, {
+            headers: { authorization: getApiKey }
+        })
         .then(async (response) => response);
-      return deleteWallet;
+
+        if (deleteWallet) {
+          await this.agentServiceRepository.deleteOrgAgentByOrg(orgId);
+        }
+
+        return deleteWallet;
     } catch (error) {
-      this.logger.error(`Error in delete wallet in agent service : ${JSON.stringify(error)}`);
-      throw new RpcException(error);
+        this.logger.error(`Error in delete wallet in agent service: ${JSON.stringify(error.message)}`);
+        throw new RpcException(error.response ? error.response : error);
     }
   }
+
 
   async receiveInvitationUrl(receiveInvitationUrl: IReceiveInvitationUrl, url: string, orgId: string): Promise<string> {
     try {

--- a/apps/agent-service/src/repositories/agent-service.repository.ts
+++ b/apps/agent-service/src/repositories/agent-service.repository.ts
@@ -483,4 +483,19 @@ export class AgentServiceRepository {
       throw error;
     }
   }
+
+  // eslint-disable-next-line camelcase
+  async deleteOrgAgentByOrg(orgId: string):Promise<org_agents> {
+    try {
+      const deleteOrgId = await this.prisma.org_agents.delete({
+        where: {
+          orgId
+        }
+      });
+      return deleteOrgId;
+    } catch (error) {
+      this.logger.error(`[deleteOrgAgentByOrg] - delete org agent record: ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
 }

--- a/apps/api-gateway/common/exception-handler.ts
+++ b/apps/api-gateway/common/exception-handler.ts
@@ -34,6 +34,12 @@ export class CustomExceptionFilter extends BaseExceptionFilter {
       exceptionResponse = exception as unknown as ExceptionResponse;
     }
 
+    if (exception?.['error']) {
+      exceptionResponse = exception?.['error'];
+    } else {
+      exceptionResponse = exception as unknown as ExceptionResponse;
+    }
+
     errorResponse = {
       statusCode: exceptionResponse.statusCode ? exceptionResponse.statusCode : status,
       message: exceptionResponse.message

--- a/apps/api-gateway/src/agent-service/agent-service.controller.ts
+++ b/apps/api-gateway/src/agent-service/agent-service.controller.ts
@@ -314,10 +314,10 @@ export class AgentController {
     await this.agentService.deleteWallet(orgId, user);
 
     const finalResponse: IResponseType = {
-      statusCode: HttpStatus.NO_CONTENT,
+      statusCode: HttpStatus.OK,
       message: ResponseMessages.agent.success.walletDelete
     };
 
-    return res.status(HttpStatus.NO_CONTENT).json(finalResponse);
+    return res.status(HttpStatus.OK).json(finalResponse);
   }
 }

--- a/apps/api-gateway/src/agent-service/agent-service.controller.ts
+++ b/apps/api-gateway/src/agent-service/agent-service.controller.ts
@@ -12,7 +12,8 @@ import {
   Res,
   Get,
   UseFilters,
-  Param
+  Param,
+  Delete
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -277,7 +278,7 @@ export class AgentController {
   @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN)
   @ApiResponse({ status: HttpStatus.CREATED, description: 'Success', type: ApiResponseDto })
-  async agentconfigure(
+  async agentConfigure(
     @Param('orgId') orgId: string,
     @Body() agentConfigureDto: AgentConfigureDto,
     @User() user: user,
@@ -295,5 +296,28 @@ export class AgentController {
     };
 
     return res.status(HttpStatus.CREATED).json(finalResponse);
+  }
+
+  @Delete('/orgs/:orgId/agents/wallet')
+  @ApiOperation({
+    summary: 'Delete wallet',
+    description: 'Delete agent wallet by organization.'
+  })
+  @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
+  @Roles(OrgRoles.OWNER)
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'Success', type: ApiResponseDto })
+  async deleteWallet(
+    @Param('orgId') orgId: string,
+    @User() user: user,
+    @Res() res: Response
+  ): Promise<Response> {
+    await this.agentService.deleteWallet(orgId, user);
+
+    const finalResponse: IResponseType = {
+      statusCode: HttpStatus.NO_CONTENT,
+      message: ResponseMessages.agent.success.walletDelete
+    };
+
+    return res.status(HttpStatus.NO_CONTENT).json(finalResponse);
   }
 }

--- a/apps/api-gateway/src/agent-service/agent-service.service.ts
+++ b/apps/api-gateway/src/agent-service/agent-service.service.ts
@@ -80,4 +80,11 @@ export class AgentService extends BaseService {
         return this.sendNatsMessage(this.agentServiceProxy, 'agent-configure', payload);
     }
 
+    async deleteWallet(orgId: string, user: user): Promise<object> {
+        const payload = { orgId, user };
+        // NATS call
+        
+        return this.sendNatsMessage(this.agentServiceProxy, 'delete-wallet', payload);
+    }
+
 }

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -516,12 +516,10 @@ export class OrganizationController {
   }
 
   /**
-   * @returns Boolean
+   * @returns Organization
    */
-  //Todo
   @Delete('/:orgId')
   @ApiOperation({ summary: 'Delete Organization', description: 'Delete an organization' })
-  @ApiExcludeEndpoint()
   @ApiResponse({ status: HttpStatus.ACCEPTED, description: 'Success', type: ApiResponseDto })
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -532,10 +532,10 @@ export class OrganizationController {
     await this.organizationService.deleteOrganization(orgId);
 
     const finalResponse: IResponse = {
-      statusCode: HttpStatus.NO_CONTENT,
+      statusCode: HttpStatus.OK,
       message: ResponseMessages.organisation.success.delete
     };
-    return res.status(HttpStatus.NO_CONTENT).json(finalResponse);
+    return res.status(HttpStatus.OK).json(finalResponse);
   }
 
   @Delete('/:orgId/client_credentials')

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -523,6 +523,7 @@ export class OrganizationController {
   @ApiResponse({ status: HttpStatus.ACCEPTED, description: 'Success', type: ApiResponseDto })
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
+  @Roles(OrgRoles.OWNER)
   async deleteOrganization(
     @Param('orgId') orgId: string, 
     @Res() res: Response
@@ -531,10 +532,10 @@ export class OrganizationController {
     await this.organizationService.deleteOrganization(orgId);
 
     const finalResponse: IResponse = {
-      statusCode: HttpStatus.ACCEPTED,
+      statusCode: HttpStatus.NO_CONTENT,
       message: ResponseMessages.organisation.success.delete
     };
-    return res.status(HttpStatus.ACCEPTED).json(finalResponse);
+    return res.status(HttpStatus.NO_CONTENT).json(finalResponse);
   }
 
   @Delete('/:orgId/client_credentials')

--- a/apps/api-gateway/src/organization/organization.service.ts
+++ b/apps/api-gateway/src/organization/organization.service.ts
@@ -204,7 +204,7 @@ export class OrganizationService extends BaseService {
 
   async deleteOrganization(
     orgId: string
-  ): Promise<boolean> {
+  ): Promise<organisation> {
     const payload = { orgId };
 
     return this.sendNatsMessage(this.serviceProxy, 'delete-organization', payload);

--- a/apps/organization/interfaces/organization.interface.ts
+++ b/apps/organization/interfaces/organization.interface.ts
@@ -176,3 +176,20 @@ export interface IPrimaryDidDetails extends IPrimaryDid {
   id: string,
   didDocument: Prisma.JsonValue
 }
+
+export interface IDeleteOrganization {
+  id: string;
+  createDateTime: Date;
+  createdBy: string;
+  lastChangedDateTime: Date;
+  lastChangedBy: string;
+  name: string;
+  description: string;
+  orgSlug: string;
+  logoUrl: string;
+  website: string;
+  publicProfile: boolean;
+  idpId: string;
+  clientId: string;
+  clientSecret: string;
+}

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -763,7 +763,7 @@ export class OrganizationRepository {
             });
 
             if (0 < isEcosystemLead.length) {
-                throw new ConflictException('This organization is an ecosystem lead or ecosystem owner.');
+                throw new ConflictException(ResponseMessages.organisation.error.organizationEcosystemValidate);
             }
 
             // User activity delete by orgId

--- a/apps/organization/src/organization.controller.ts
+++ b/apps/organization/src/organization.controller.ts
@@ -6,7 +6,7 @@ import { Body } from '@nestjs/common';
 import { CreateOrganizationDto } from '../dtos/create-organization.dto';
 import { BulkSendInvitationDto } from '../dtos/send-invitation.dto';
 import { UpdateInvitationDto } from '../dtos/update-invitation.dt';
-import { IDidList, IGetOrgById, IGetOrganization, IUpdateOrganization, Payload } from '../interfaces/organization.interface';
+import { IDeleteOrganization, IDidList, IGetOrgById, IGetOrganization, IUpdateOrganization, Payload } from '../interfaces/organization.interface';
 import { organisation } from '@prisma/client';
 import { IOrgCredentials, IOrganizationInvitations, IOrganization, IOrganizationDashboard } from '@credebl/common/interfaces/organization.interface';
 import { IAccessTokenData } from '@credebl/common/interfaces/interface';
@@ -227,7 +227,7 @@ export class OrganizationController {
   }
 
   @MessagePattern({ cmd: 'delete-organization' })
-  async deleteOrganization(payload: { orgId: string }): Promise<boolean> {
+  async deleteOrganization(payload: { orgId: string }): Promise<IDeleteOrganization> {
     return this.organizationService.deleteOrganization(payload.orgId);
   }
 

--- a/libs/common/src/common.constant.ts
+++ b/libs/common/src/common.constant.ts
@@ -118,6 +118,7 @@ export enum CommonConstants {
   URL_SHAGENT_SEND_QUESTION = '/multi-tenancy/question-answer/question/#/@',
   URL_SHAGENT_SEND_ANSWER = '/multi-tenancy/question-answer/answer/#/@',
   URL_SHAGENT_QUESTION_ANSWER_RECORD = '/multi-tenancy/question-answer/#',
+  URL_SHAGENT_DELETE_SUB_WALLET = '/multi-tenancy/#',
   
   // PROOF SERVICES
   URL_SEND_PROOF_REQUEST = '/proofs/request-proof',

--- a/libs/common/src/common.service.ts
+++ b/libs/common/src/common.service.ts
@@ -232,13 +232,13 @@ export class CommonService {
     }
   }
 
-  async httpDelete(url: string, config?: unknown): Promise<object> {
+  async httpDelete(url: string, config?: unknown) {
     try {
       return await this.httpService
         .delete(url, config)
         .toPromise()
         .then((data) => {
-          return data.data;
+          return data;
         });
     } catch (error) {
       this.logger.error(`ERROR in DELETE : ${JSON.stringify(error.response.data)}`);

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -210,7 +210,8 @@ export const ResponseMessages = {
             ledgerConfig: 'Ledger config details fetched successfully.',
             webhookUrlRegister:'Webhook Url registered successfully',
             getWebhookUrl:'Webhook Url fetched successfully',
-            createKeys:'Key-pair created successfully'
+            createKeys:'Key-pair created successfully',
+            walletDelete: 'Wallet deleted successfully'
         },
         error: {
             exists: 'An agent name is already exist',

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -119,7 +119,8 @@ export const ResponseMessages = {
             invalidClient: 'Invalid client credentials',
             primaryDid: 'This DID is already set to primary DID',
             didNotFound: 'DID does not exist in organiation',
-            MaximumOrgsLimit:'Limit reached: You can be associated with or create maximum 10 organizations.'
+            MaximumOrgsLimit:'Limit reached: You can be associated with or create maximum 10 organizations.',
+            organizationEcosystemValidate: 'This organization is an ecosystem lead or ecosystem owner.'
         }
     },
 
@@ -250,7 +251,8 @@ export const ResponseMessages = {
             failedAgentType: 'Agent endpoint is required',
             failedApiKey: 'Failed to encrypt API key',
             failedOrganization: 'Failed to fetch organization agent type details',
-            promiseReject: 'One or more promises were rejected.'
+            promiseReject: 'One or more promises were rejected.',
+            orgAgentNotFound: 'Org agent type not found'
         }
     },
     connection: {

--- a/libs/http-exception.filter.ts
+++ b/libs/http-exception.filter.ts
@@ -1,79 +1,95 @@
-import { Catch, ExceptionFilter, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { ResponseMessages } from '@credebl/common/response-messages';
+import { Catch, ExceptionFilter, HttpStatus, Logger } from '@nestjs/common';
 import { RpcException } from '@nestjs/microservices';
-import { PrismaClientKnownRequestError, PrismaClientValidationError } from '@prisma/client/runtime/library';
 import { Observable, throwError } from 'rxjs';
 
 @Catch()
 export class HttpExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger('CommonService');
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-  catch(exception: any): Observable<any> {
+  catch(exception: unknown): Observable<never> {
     this.logger.error(`AnyExceptionFilter caught error: ${JSON.stringify(exception)}`);
+    const { httpStatus, message, error } = this.getExceptionDetails(exception);
+    return throwError(() => new RpcException({ message, statusCode: httpStatus, error }));
+  }
 
-    let httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-    let message = '';
-    switch (exception.constructor) {
-      case HttpException:
-        this.logger.error(`Its HttpException`);
-        httpStatus = exception.getStatus() || HttpStatus.BAD_REQUEST;
-        message = exception?.getResponse() || exception.message;
-        break;
-      case RpcException:
-        this.logger.error(`Its RpcException`);
-        return throwError(() => exception.getError());
-        break;
-      case PrismaClientKnownRequestError:
-        this.logger.error(`Its PrismaClientKnownRequestError`);
-        switch (exception.code) {
-          case 'P2002': // Unique constraint failed on the {constraint}
-          case 'P2000': // The provided value for the column is too long for the column's type. Column: {column_name}
-          case 'P2001': // The record searched for in the where condition ({model_name}.{argument_name} = {argument_value}) does not exist
-          case 'P2005': // The value {field_value} stored in the database for the field {field_name} is invalid for the field's type
-          case 'P2006': // The provided value {field_value} for {model_name} field {field_name} is not valid
-          case 'P2010': // Raw query failed. Code: {code}. Message: {message}
-          case 'P2011': // Null constraint violation on the {constraint}
-          case 'P2017': // The records for relation {relation_name} between the {parent_name} and {child_name} models are not connected.
-          case 'P2021': // The table {table} does not exist in the current database.
-          case 'P2022': // The column {column} does not exist in the current database.          
-            httpStatus = HttpStatus.BAD_REQUEST;
-            message = exception?.response?.message || exception?.message;
-            break;
-          case 'P2023': // Inconsistent column data: {message}
-            httpStatus = HttpStatus.BAD_REQUEST;
-            message = exception?.meta?.message || exception?.message;
-            break;
-          case 'P2018': // The required connected records were not found. {details}
-          case 'P2025': // An operation failed because it depends on one or more records that were required but not found. {cause}
-          case 'P2015': // A related record could not be found. {details}
-            httpStatus = HttpStatus.NOT_FOUND;
-            message = exception?.message;
-            break;
-          default:
-            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-            message = exception?.response?.message || exception?.message || 'Internal server error';
-        }
-        break;
-      case PrismaClientValidationError:
-        this.logger.error(`Its PrismaClientValidationError`);
-        httpStatus = HttpStatus.BAD_REQUEST;
-        message = exception?.message || exception?.response?.message;
-        break;
+  private getExceptionDetails(exception): { httpStatus: number, message: string, error: string } {
+    switch (exception.error.name) {
+      case 'HttpException':
+        return this.handleHttpException(exception);
+      case 'RpcException':
+        return this.handleRpcException(exception);
+      case 'PrismaClientKnownRequestError':
+        return this.handlePrismaClientKnownRequestError(exception);
+      case 'PrismaClientValidationError':
+        return this.handlePrismaClientValidationError(exception);
       default:
-        this.logger.error(`Its an Unknown Exception`);
-        // eslint-disable-next-line no-case-declarations
-        httpStatus =
-          exception.response?.status ||
-          exception.response?.statusCode ||
-          exception.code ||
-          HttpStatus.INTERNAL_SERVER_ERROR;
-        // eslint-disable-next-line no-case-declarations
-        message =
-          exception.response?.data?.message ||
-          exception.response?.message ||
-          exception?.message ||
-          'Internal server error';
+        return this.handleUnknownException(exception);
     }
-    return throwError(() => new RpcException({ message, code: httpStatus }));
+  }
+
+  private handleHttpException(exception): { httpStatus: number, message: string, error: string } {
+    this.logger.error(`It's HttpException`);
+    const httpStatus = exception.getStatus() || HttpStatus.BAD_REQUEST;
+    const message = exception?.getResponse() || exception.message;
+    return { httpStatus, message, error: ResponseMessages.errorMessages.serverError };
+  }
+
+  private handleRpcException(exception): never {
+    this.logger.error(`It's RpcException`);
+    throw exception.getError();
+  }
+
+  private handlePrismaClientKnownRequestError(exception): { httpStatus: number, message: string, error: string } {
+    this.logger.error(`It's PrismaClientKnownRequestError`);
+    const errorCode = exception.error.code;
+    const message = exception?.error?.meta?.message ?? exception?.error?.meta?.cause ?? exception?.message;
+
+    switch (errorCode) {
+      case 'P2002': // Unique constraint failed on the {constraint}
+      case 'P2010': // Raw query failed. Code: {code}. Message: {message}
+      case 'P2011': // Null constraint violation on the {constraint}
+        return { httpStatus: HttpStatus.INTERNAL_SERVER_ERROR, message, error: ResponseMessages.errorMessages.serverError };
+      case 'P2000': // The provided value for the column is too long for the column's type. Column: {column_name}
+      case 'P2005': // The value {field_value} stored in the database for the field {field_name} is invalid for the field's type
+      case 'P2006': // The provided value {field_value} for {model_name} field {field_name} is not valid
+      case 'P2017': // The records for relation {relation_name} between the {parent_name} and {child_name} models are not connected.
+        return { httpStatus: HttpStatus.CONFLICT, message, error: ResponseMessages.errorMessages.conflict };
+      case 'P2001': // The record searched for in the where condition ({model_name}.{argument_name} = {argument_value}) does not exist
+      case 'P2015': // A related record could not be found. {details}
+      case 'P2018': // The required connected records were not found. {details}
+      case 'P2025': // An operation failed because it depends on one or more records that were required but not found. {cause}
+        return { httpStatus: HttpStatus.NOT_FOUND, message, error: ResponseMessages.errorMessages.notFound };
+      case 'P2021': // The table {table} does not exist in the current database.
+      case 'P2022': // The column {column} does not exist in the current database.
+      case 'P2023': // Inconsistent column data: {message}
+        return { httpStatus: HttpStatus.BAD_REQUEST, message, error: ResponseMessages.errorMessages.badRequest };
+      default:
+        return { httpStatus: HttpStatus.INTERNAL_SERVER_ERROR, message, error: ResponseMessages.errorMessages.serverError };
+    }
+  }
+
+  private handlePrismaClientValidationError(exception): { httpStatus: number, message: string, error: string } {
+    this.logger.error(`It's PrismaClientValidationError`);
+    const httpStatus = HttpStatus.BAD_REQUEST;
+    const message = exception?.meta?.message ?? exception?.error?.meta?.cause ?? exception?.message ?? exception?.response?.message;
+    return { httpStatus, message, error: ResponseMessages.errorMessages.badRequest };
+  }
+
+  private handleUnknownException(exception): { httpStatus: number, message: string, error: string } {
+    this.logger.error(`It's an Unknown Exception`);
+    const httpStatus =
+      exception.response?.status ??
+      exception.response?.statusCode ??
+      exception?.error?.meta?.cause ??
+      exception.code ??
+      HttpStatus.INTERNAL_SERVER_ERROR;
+    const message =
+      exception.response?.data?.message ??
+      exception.response?.message ??
+      exception?.error?.meta?.cause ??
+      exception?.message ??
+      'Internal server error';
+    return { httpStatus, message, error: ResponseMessages.errorMessages.serverError };
   }
 }


### PR DESCRIPTION
### What ###
Delete both an organization and its associated wallet from the system. This involves:
- Adding a new endpoint to handle the deletion process.
- Ensuring that when an organization is deleted, its associated wallet is also deleted.
- Updating the relevant documentation to reflect these changes.

### Why ###
This feature is necessary to improve the user experience by allowing complete and clean removal of organizations.

### How ###

- Endpoint Addition: A new API endpoint /org/{orgId} is created to handle the delete request.

Database Operations:

- Fetch the organization and its associated wallet details from the database.
- Error Handling: Implement error handling to manage cases where the organization or wallet cannot be found, ensuring appropriate responses are returned.