### PR TITLE
feat: fetch org activity count

### DIFF
--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -177,6 +177,25 @@ export class OrganizationController {
 
   }
 
+  @Get('/activity-count/:orgId')
+  @ApiOperation({ summary: 'Get organization references count', description: 'Get organization references count by org Id' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
+  @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
+  @ApiBearerAuth()
+  @Roles(OrgRoles.OWNER)
+  async getOrganizationActivityCount(@Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, @Res() res: Response, @User() reqUser: user): Promise<Response> {
+
+    const getOrganization = await this.organizationService.getOrganizationActivityCount(orgId, reqUser.id);
+
+    const finalResponse: IResponse = {
+      statusCode: HttpStatus.OK,
+      message: ResponseMessages.organisation.success.getOrganizationActivity,
+      data: getOrganization
+    };
+    return res.status(HttpStatus.OK).json(finalResponse);
+
+  }
+
   @Get('/:orgId/invitations')
   @ApiOperation({ summary: 'Get all invitations', description: 'Get all invitations' })
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })

--- a/apps/api-gateway/src/organization/organization.service.ts
+++ b/apps/api-gateway/src/organization/organization.service.ts
@@ -9,7 +9,7 @@ import { UpdateOrganizationDto } from './dtos/update-organization-dto';
 import { organisation, user } from '@prisma/client';
 import { IDidList, IGetOrgById, IGetOrganization } from 'apps/organization/interfaces/organization.interface';
 import { IOrgUsers } from 'apps/user/interfaces/user.interface';
-import { IOrgCredentials, IOrganization, IOrganizationInvitations, IOrganizationDashboard, IDeleteOrganization, IOrgReferencesCount } from '@credebl/common/interfaces/organization.interface';
+import { IOrgCredentials, IOrganization, IOrganizationInvitations, IOrganizationDashboard, IDeleteOrganization, IOrgActivityCount } from '@credebl/common/interfaces/organization.interface';
 import { ClientCredentialsDto } from './dtos/client-credentials.dto';
 import { IAccessTokenData } from '@credebl/common/interfaces/interface';
 import { PaginationDto } from '@credebl/common/dtos/pagination.dto';
@@ -140,7 +140,7 @@ export class OrganizationService extends BaseService {
     return this.sendNatsMessage(this.serviceProxy, 'get-organization-dashboard', payload);
   }
 
-  async getOrganizationActivityCount(orgId: string, userId: string): Promise<IOrgReferencesCount> {
+  async getOrganizationActivityCount(orgId: string, userId: string): Promise<IOrgActivityCount> {
     const payload = { orgId, userId };
     return this.sendNatsMessage(this.serviceProxy, 'get-organization-activity-count', payload);
   }

--- a/apps/api-gateway/src/organization/organization.service.ts
+++ b/apps/api-gateway/src/organization/organization.service.ts
@@ -9,7 +9,7 @@ import { UpdateOrganizationDto } from './dtos/update-organization-dto';
 import { organisation } from '@prisma/client';
 import { IDidList, IGetOrgById, IGetOrganization } from 'apps/organization/interfaces/organization.interface';
 import { IOrgUsers } from 'apps/user/interfaces/user.interface';
-import { IOrgCredentials, IOrganization, IOrganizationInvitations, IOrganizationDashboard, IDeleteOrganization } from '@credebl/common/interfaces/organization.interface';
+import { IOrgCredentials, IOrganization, IOrganizationInvitations, IOrganizationDashboard, IDeleteOrganization, IOrgReferencesCount } from '@credebl/common/interfaces/organization.interface';
 import { ClientCredentialsDto } from './dtos/client-credentials.dto';
 import { IAccessTokenData } from '@credebl/common/interfaces/interface';
 import { PaginationDto } from '@credebl/common/dtos/pagination.dto';
@@ -138,6 +138,11 @@ export class OrganizationService extends BaseService {
   async getOrganizationDashboard(orgId: string, userId: string): Promise<IOrganizationDashboard> {
     const payload = { orgId, userId };
     return this.sendNatsMessage(this.serviceProxy, 'get-organization-dashboard', payload);
+  }
+
+  async getOrganizationActivityCount(orgId: string, userId: string): Promise<IOrgReferencesCount> {
+    const payload = { orgId, userId };
+    return this.sendNatsMessage(this.serviceProxy, 'get-organization-activity-count', payload);
   }
 
   /**

--- a/apps/connection/src/connection.controller.ts
+++ b/apps/connection/src/connection.controller.ts
@@ -63,6 +63,12 @@ export class ConnectionController {
     return this.connectionService.getConnectionsById(user, connectionId, orgId);
   }
 
+  @MessagePattern({ cmd: 'get-connection-records' })
+  async getConnectionRecordsByOrgId(payload: { orgId: string, userId: string }): Promise<number> {
+    const { orgId } = payload;
+    return this.connectionService.getConnectionRecords(orgId);
+  }
+
   @MessagePattern({ cmd: 'receive-invitation-url' })
   async receiveInvitationUrl(payload: IReceiveInvitationByUrlOrg): Promise<IReceiveInvitationResponse> {
     const { user, receiveInvitationUrl, orgId } = payload;

--- a/apps/connection/src/connection.repository.ts
+++ b/apps/connection/src/connection.repository.ts
@@ -89,6 +89,22 @@ export class ConnectionRepository {
     }
   }
 
+
+  async getConnectionRecordsCount(orgId: string): Promise<number> {
+    try {
+      const connectionRecordsCount = await this.prisma.connections.count({
+        where: {
+          orgId
+        }
+      });
+      return connectionRecordsCount;
+    } catch (error) {
+      this.logger.error(`[get connection records by org Id] - error: ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
+
   /**
    * Description: Save connection details
    * @param connectionInvitation

--- a/apps/connection/src/connection.service.ts
+++ b/apps/connection/src/connection.service.ts
@@ -89,6 +89,18 @@ export class ConnectionService {
     }
   }
 
+  async getConnectionRecords(orgId: string): Promise<number> {
+    try {
+      return await this.connectionRepository.getConnectionRecordsCount(orgId);
+    } catch (error) {
+                    
+      this.logger.error(
+        `[getConnectionRecords ] [NATS call]- error in get connection records count : ${JSON.stringify(error)}`
+      );
+      throw new RpcException(error.response ? error.response : error);
+    }
+  }
+
   /**
    * Description: Fetch connection invitaion by referenceId
    * @param referenceId

--- a/apps/ecosystem/src/ecosystem.controller.ts
+++ b/apps/ecosystem/src/ecosystem.controller.ts
@@ -126,6 +126,12 @@ export class EcosystemController {
     return this.ecosystemService.acceptRejectEcosystemInvitations(payload.acceptRejectInvitation, payload.userEmail);
   }
 
+  @MessagePattern({ cmd: 'get-ecosystem-records' })
+  async getEcosystemsByOrgId(payload: { orgId: string, userId: string }): Promise<number> {
+    const { orgId } = payload;
+    return this.ecosystemService.getEcosystems(orgId);
+  }
+
   @MessagePattern({ cmd: 'get-sent-invitations-ecosystemId' })
   async getInvitationsByOrgId(@Body() payload: FetchInvitationsPayload): Promise<IEcosystemInvitation> {
     return this.ecosystemService.getInvitationsByEcosystemId(payload);

--- a/apps/ecosystem/src/ecosystem.repository.ts
+++ b/apps/ecosystem/src/ecosystem.repository.ts
@@ -122,6 +122,24 @@ export class EcosystemRepository {
     }
   }
 
+  async getEcosystemsCount(orgId: string): Promise<number> {
+    try {
+      const ecosystemsCount = await this.prisma.ecosystem.count({
+        where: {
+          ecosystemOrgs: {
+            some: {
+              orgId
+            }
+          }
+        }
+      });
+      return ecosystemsCount;
+    } catch (error) {
+      this.logger.error(`[get all ecosystems by org Id] - error: ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
   async checkOrgExists(orgId: string): Promise<organisation> {
     try {
       const isOrgExists = await this.prisma.organisation.findUnique({

--- a/apps/ecosystem/src/ecosystem.service.ts
+++ b/apps/ecosystem/src/ecosystem.service.ts
@@ -164,6 +164,19 @@ export class EcosystemService {
     return orgData;
   }
 
+
+  async getEcosystems(orgId: string): Promise<number> {
+    try {
+      return await this.ecosystemRepository.getEcosystemsCount(orgId);
+    } catch (error) {
+                    
+      this.logger.error(
+        `[getEcosystemsCount ] [NATS call]- error in get ecosystems count : ${JSON.stringify(error)}`
+      );
+      throw new RpcException(error.response ? error.response : error);
+    }
+  }
+
   /**
    *
    * @param editEcosystemDto

--- a/apps/issuance/src/issuance.controller.ts
+++ b/apps/issuance/src/issuance.controller.ts
@@ -9,6 +9,12 @@ import { OOBIssueCredentialDto } from 'apps/api-gateway/src/issuance/dtos/issuan
 export class IssuanceController {
   constructor(private readonly issuanceService: IssuanceService) { }
 
+  @MessagePattern({ cmd: 'get-issuance-records' })
+  async getIssuanceRecordsByOrgId(payload: { orgId: string, userId: string }): Promise<number> {
+    const { orgId } = payload;
+    return this.issuanceService.getIssuanceRecords(orgId);
+  }
+
   @MessagePattern({ cmd: 'send-credential-create-offer' })
   async sendCredentialCreateOffer(payload: IIssuance): Promise<PromiseSettledResult<ICreateOfferResponse>[]> {
     return this.issuanceService.sendCredentialCreateOffer(payload);

--- a/apps/issuance/src/issuance.repository.ts
+++ b/apps/issuance/src/issuance.repository.ts
@@ -60,6 +60,20 @@ export class IssuanceRepository {
     }
   }
 
+  async getIssuanceRecordsCount(orgId: string): Promise<number> {
+    try {
+      const issuanceRecordsCount = await this.prisma.credentials.count({
+        where: {
+          orgId
+        }
+      });
+      return issuanceRecordsCount;
+    } catch (error) {
+      this.logger.error(`[get issuance records by org Id] - error: ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
   async getOrganizationByTenantId(tenantId: string): Promise<org_agents> {
     try {
       return this.prisma.org_agents.findFirst({

--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -51,6 +51,18 @@ export class IssuanceService {
     @Inject(CACHE_MANAGER) private cacheService: Cache
   ) { }
 
+  async getIssuanceRecords(orgId: string): Promise<number> {
+    try {
+      return await this.issuanceRepository.getIssuanceRecordsCount(orgId);
+    } catch (error) {
+                    
+      this.logger.error(
+        `[getIssuanceRecords ] [NATS call]- error in get issuance records count : ${JSON.stringify(error)}`
+      );
+      throw new RpcException(error.response ? error.response : error);
+    }
+  }
+
   async sendCredentialCreateOffer(payload: IIssuance): Promise<PromiseSettledResult<ICreateOfferResponse>[]> {
     try {
       const { orgId, credentialDefinitionId, comment, credentialData } = payload || {};

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -302,6 +302,20 @@ export class OrganizationRepository {
     }
   }
 
+
+  async getOrgInvitationsCount(orgId: string): Promise<number> {
+    try {
+      return this.prisma.org_invitations.count({
+        where: {
+          orgId
+        }
+      });
+    } catch (error) {
+      this.logger.error(`error: ${JSON.stringify(error)}`);
+      throw new InternalServerErrorException(error);
+    }
+  }
+
   async getOrgInvitationsPagination(queryObject: object, pageNumber: number, pageSize: number): Promise<IOrganizationInvitations> {
     try {
       const result = await this.prisma.$transaction([

--- a/apps/organization/src/organization.controller.ts
+++ b/apps/organization/src/organization.controller.ts
@@ -5,7 +5,7 @@ import { CreateOrganizationDto } from '../dtos/create-organization.dto';
 import { BulkSendInvitationDto } from '../dtos/send-invitation.dto';
 import { UpdateInvitationDto } from '../dtos/update-invitation.dt';
 import { IDidList, IGetOrgById, IGetOrganization, IUpdateOrganization, Payload } from '../interfaces/organization.interface';
-import { IOrgCredentials, IOrganizationInvitations, IOrganization, IOrganizationDashboard, IDeleteOrganization, IOrgReferencesCount } from '@credebl/common/interfaces/organization.interface';
+import { IOrgCredentials, IOrganizationInvitations, IOrganization, IOrganizationDashboard, IDeleteOrganization, IOrgActivityCount } from '@credebl/common/interfaces/organization.interface';
 import { organisation, user } from '@prisma/client';
 import { IAccessTokenData } from '@credebl/common/interfaces/interface';
 import { IClientRoles } from '@credebl/client-registration/interfaces/client.interface';
@@ -207,7 +207,7 @@ export class OrganizationController {
   }
 
   @MessagePattern({ cmd: 'get-organization-activity-count' })
-  async getOrganizationActivityCount(payload: { orgId: string; userId: string }): Promise<IOrgReferencesCount> {
+  async getOrganizationActivityCount(payload: { orgId: string; userId: string }): Promise<IOrgActivityCount> {
     return this.organizationService.getOrganizationActivityCount(payload.orgId, payload.userId);
   }
 

--- a/apps/organization/src/organization.controller.ts
+++ b/apps/organization/src/organization.controller.ts
@@ -8,7 +8,7 @@ import { BulkSendInvitationDto } from '../dtos/send-invitation.dto';
 import { UpdateInvitationDto } from '../dtos/update-invitation.dt';
 import { IDidList, IGetOrgById, IGetOrganization, IUpdateOrganization, Payload } from '../interfaces/organization.interface';
 import { organisation } from '@prisma/client';
-import { IOrgCredentials, IOrganizationInvitations, IOrganization, IOrganizationDashboard, IDeleteOrganization } from '@credebl/common/interfaces/organization.interface';
+import { IOrgCredentials, IOrganizationInvitations, IOrganization, IOrganizationDashboard, IDeleteOrganization, IOrgReferencesCount } from '@credebl/common/interfaces/organization.interface';
 import { IAccessTokenData } from '@credebl/common/interfaces/interface';
 import { IClientRoles } from '@credebl/client-registration/interfaces/client.interface';
 
@@ -206,6 +206,11 @@ export class OrganizationController {
   @MessagePattern({ cmd: 'get-organization-dashboard' })
   async getOrgDashboard(payload: { orgId: string; userId: string }): Promise<IOrganizationDashboard> {
     return this.organizationService.getOrgDashboard(payload.orgId);
+  }
+
+  @MessagePattern({ cmd: 'get-organization-activity-count' })
+  async getOrganizationActivityCount(payload: { orgId: string; userId: string }): Promise<IOrgReferencesCount> {
+    return this.organizationService.getOrganizationActivityCount(payload.orgId, payload.userId);
   }
 
 /**

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -40,7 +40,7 @@ import {
   IOrganizationInvitations,
   IOrganizationDashboard,
   IDeleteOrganization,
-  IOrgReferencesCount
+  IOrgActivityCount
 } from '@credebl/common/interfaces/organization.interface';
 
 import { ClientCredentialTokenPayloadDto } from '@credebl/client-registration/dtos/client-credential-token-payload.dto';
@@ -1264,7 +1264,7 @@ export class OrganizationService {
   }
 
 
-  async getOrganizationActivityCount(orgId: string, userId: string): Promise<IOrgReferencesCount> {
+  async getOrganizationActivityCount(orgId: string, userId: string): Promise<IOrgActivityCount> {
     try {
       const [
         verificationRecordsCount,

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -39,7 +39,8 @@ import {
   IOrganization,
   IOrganizationInvitations,
   IOrganizationDashboard,
-  IDeleteOrganization
+  IDeleteOrganization,
+  IOrgReferencesCount
 } from '@credebl/common/interfaces/organization.interface';
 
 import { ClientCredentialTokenPayloadDto } from '@credebl/client-registration/dtos/client-credential-token-payload.dto';
@@ -1257,6 +1258,131 @@ export class OrganizationService {
       this.logger.error(`In create organization : ${JSON.stringify(error)}`);
       throw new RpcException(error.response ? error.response : error);
     }
+  }
+
+
+  async getOrganizationActivityCount(orgId: string, userId: string): Promise<IOrgReferencesCount> {
+    try {
+      const [
+        verificationRecordsCount,
+        issuanceRecordsCount,
+        connectionRecordsCount,
+        orgInvitationsCount, 
+        orgUsers,
+        orgEcosystemsCount
+      ] = await Promise.all([
+        this._getVerificationRecordsCount(orgId, userId),
+        this._getIssuanceRecordsCount(orgId, userId),
+        this._getConnectionRecordsCount(orgId, userId),
+        this.organizationRepository.getOrgInvitationsCount(orgId),
+        this.organizationRepository.getOrgDashboard(orgId),
+        this._getEcosystemsCount(orgId, userId)
+      ]);
+
+      const orgUsersCount = orgUsers?.['usersCount'];
+
+      return {verificationRecordsCount, issuanceRecordsCount, connectionRecordsCount, orgUsersCount, orgEcosystemsCount, orgInvitationsCount};
+    } catch (error) {
+      this.logger.error(`In fetch organization references count : ${JSON.stringify(error)}`);
+      throw new RpcException(error.response ? error.response : error);
+    }
+  }
+
+  async _getEcosystemsCount(orgId: string, userId: string): Promise<number> {
+    const pattern = { cmd: 'get-ecosystem-records' };
+
+    const payload = {
+      orgId,
+      userId
+    };
+    const ecosystemsCount = await this.organizationServiceProxy
+      .send(pattern, payload)
+      .toPromise()
+      .catch((error) => {
+        this.logger.error(`catch: ${JSON.stringify(error)}`);
+        throw new HttpException(
+          {
+            status: error.status,
+            error: error.message
+          },
+          error.status
+        );
+      });
+
+    return ecosystemsCount;
+  }
+
+  async _getConnectionRecordsCount(orgId: string, userId: string): Promise<number> {
+    const pattern = { cmd: 'get-connection-records' };
+
+    const payload = {
+      orgId,
+      userId
+    };
+    const connectionsCount = await this.organizationServiceProxy
+      .send(pattern, payload)
+      .toPromise()
+      .catch((error) => {
+        this.logger.error(`catch: ${JSON.stringify(error)}`);
+        throw new HttpException(
+          {
+            status: error.status,
+            error: error.message
+          },
+          error.status
+        );
+      });
+
+    return connectionsCount;
+  }
+
+
+  async _getIssuanceRecordsCount(orgId: string, userId: string): Promise<number> {
+    const pattern = { cmd: 'get-issuance-records' };
+
+    const payload = {
+      orgId,
+      userId
+    };
+    const issuanceCount = await this.organizationServiceProxy
+      .send(pattern, payload)
+      .toPromise()
+      .catch((error) => {
+        this.logger.error(`catch: ${JSON.stringify(error)}`);
+        throw new HttpException(
+          {
+            status: error.status,
+            error: error.message
+          },
+          error.status
+        );
+      });
+
+    return issuanceCount;
+  }
+
+  async _getVerificationRecordsCount(orgId: string, userId: string): Promise<number> {
+    const pattern = { cmd: 'get-verification-records' };
+
+    const payload = {
+      orgId,
+      userId
+    };
+    const verificationCount = await this.organizationServiceProxy
+      .send(pattern, payload)
+      .toPromise()
+      .catch((error) => {
+        this.logger.error(`catch: ${JSON.stringify(error)}`);
+        throw new HttpException(
+          {
+            status: error.status,
+            error: error.message
+          },
+          error.status
+        );
+      });
+
+    return verificationCount;
   }
 
   async getOrgPofile(orgId: string): Promise<organisation> {

--- a/apps/verification/src/repositories/verification.repository.ts
+++ b/apps/verification/src/repositories/verification.repository.ts
@@ -103,6 +103,20 @@ export class VerificationRepository {
     }
   }
 
+  async getVerificationRecordsCount(orgId: string): Promise<number> {
+    try {
+      const verificationRecordsCount = await this.prisma.presentations.count({
+        where: {
+          orgId
+        }
+      });
+      return verificationRecordsCount;
+    } catch (error) {
+      this.logger.error(`[get verification records by org Id] - error: ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
   async storeProofPresentation(payload: IProofPresentation): Promise<presentations> {
     try {
       let organisationId: string;

--- a/apps/verification/src/verification.controller.ts
+++ b/apps/verification/src/verification.controller.ts
@@ -21,6 +21,12 @@ export class VerificationController {
     return this.verificationService.getProofPresentations(user, orgId, proofRequestsSearchCriteria);
   }
 
+  @MessagePattern({ cmd: 'get-verification-records' })
+  async getVerificationRecordsByOrgId(payload: { orgId: string, userId: string }): Promise<number> {
+    const { orgId } = payload;
+    return this.verificationService.getVerificationRecords(orgId);
+  }
+
   /**
    * Get proof presentation by proofId
    * @param orgId 

--- a/apps/verification/src/verification.service.ts
+++ b/apps/verification/src/verification.service.ts
@@ -94,6 +94,19 @@ export class VerificationService {
     }
   }
 
+  async getVerificationRecords(orgId: string): Promise<number> {
+    try {
+      return await this.verificationRepository.getVerificationRecordsCount(orgId);
+    } catch (error) {
+                    
+      this.logger.error(
+        `[getVerificationRecords ] [NATS call]- error in get verification records count : ${JSON.stringify(error)}`
+      );
+      throw new RpcException(error.response ? error.response : error);
+    }
+  }
+
+
   /**
    * Consume agent API for get all proof presentations
    * @param payload 

--- a/libs/common/src/interfaces/organization.interface.ts
+++ b/libs/common/src/interfaces/organization.interface.ts
@@ -93,3 +93,12 @@ export interface IOrganizationDashboard {
     clientId: string;
     clientSecret: string;
   }
+  export interface IOrgReferencesCount {
+    verificationRecordsCount: number;
+    issuanceRecordsCount: number;
+    connectionRecordsCount: number;
+    orgUsersCount: number;
+    orgEcosystemsCount: number;
+    orgInvitationsCount: number;
+  }
+  

--- a/libs/common/src/interfaces/organization.interface.ts
+++ b/libs/common/src/interfaces/organization.interface.ts
@@ -93,7 +93,7 @@ export interface IOrganizationDashboard {
     clientId: string;
     clientSecret: string;
   }
-  export interface IOrgReferencesCount {
+  export interface IOrgActivityCount {
     verificationRecordsCount: number;
     issuanceRecordsCount: number;
     connectionRecordsCount: number;

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -86,8 +86,8 @@ export const ResponseMessages = {
             deleteCredentials:'Organization client credentials deleted',
             orgDids: 'Organization DIDs fetched successfully',
             primaryDid: 'Primary DID updated successfully',
-            didDetails: 'DID Details updated sucessfully'
-
+            didDetails: 'DID Details updated sucessfully',
+            getOrganizationActivity: 'Organization activity count fetched successfully'
         },
         error: {
             exists: 'An organization name is already exist',


### PR DESCRIPTION
### What?
1). Implemented API to fetch organization activity count
- Implemented function to get verification records count
- Implemented function to get issuance records count
- Implemented function to get connection records count
- Implemented function to get organization invitations count
- Implemented function to get organization ecosystems count
- Implemented function to get organization users count

### Why?
- Implementing an API to fetch organization activity count allows for tracking various actions within an organization