### PR TITLE
fix: added the empty string in user_org_delete_activity table

### DIFF
--- a/libs/prisma-service/prisma/migrations/20240611134959_added_null_user_org_delete_activity/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20240611134959_added_null_user_org_delete_activity/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_org_delete_activity" ALTER COLUMN "userEmail" SET DEFAULT '';

--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -520,7 +520,7 @@ model ledgerConfig {
 
 model user_org_delete_activity {
   id             String     @id @default(uuid()) @db.Uuid
-  userEmail      String
+  userEmail      String     @default("")
   userId         String     @db.Uuid
   orgId          String     @db.Uuid
   recordType     RecordType


### PR DESCRIPTION
### What ###
Addition of an empty string in the user_org_delete_activity table.

### Why ###
The empty string addition is essential for maintaining data integrity and ensuring compatibility with existing database structures. It helps in accommodating scenarios where certain fields may not have specific values but still require placeholders.

### How ###
The addition of the empty string is implemented by modifying the schema definition or updating relevant SQL scripts to include the appropriate default value for the respective column in the user_org_delete_activity table. Additionally, any necessary documentation updates or test cases should be included to reflect this change accurately.