### PR TITLE
feat: keycloak clientId and client secret manage on the user table

### DIFF
--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -106,9 +106,9 @@ export class OrganizationController {
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
-  async getOrgRoles(@Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, @Res() res: Response): Promise<Response> {
+  async getOrgRoles(@Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, @User() user: user, @Res() res: Response): Promise<Response> {
 
-    const orgRoles = await this.organizationService.getOrgRoles(orgId.trim());
+    const orgRoles = await this.organizationService.getOrgRoles(orgId.trim(), user);
 
     const finalResponse: IResponse = {
       statusCode: HttpStatus.OK,
@@ -564,9 +564,9 @@ export class OrganizationController {
   @ApiBearerAuth()
   @ApiExcludeEndpoint()
   @UseGuards(AuthGuard('jwt'))
-  async deleteOrgClientCredentials(@Param('orgId') orgId: string, @Res() res: Response): Promise<Response> {
+  async deleteOrgClientCredentials(@Param('orgId') orgId: string, @Res() res: Response, @User() user: user): Promise<Response> {
 
-    const deleteResponse = await this.organizationService.deleteOrgClientCredentials(orgId);
+    const deleteResponse = await this.organizationService.deleteOrgClientCredentials(orgId, user);
 
     const finalResponse: IResponse = {
       statusCode: HttpStatus.ACCEPTED,

--- a/apps/api-gateway/src/organization/organization.service.ts
+++ b/apps/api-gateway/src/organization/organization.service.ts
@@ -151,8 +151,8 @@ export class OrganizationService extends BaseService {
    * @returns get organization roles
    */
 
-  async getOrgRoles(orgId: string): Promise<IClientRoles[]> {
-    const payload = {orgId};
+  async getOrgRoles(orgId: string, user: user): Promise<IClientRoles[]> {
+    const payload = {orgId, user};
     return this.sendNatsMessage(this.serviceProxy, 'get-org-roles', payload);
   }
 
@@ -217,9 +217,10 @@ export class OrganizationService extends BaseService {
   }
 
   async deleteOrgClientCredentials(
-    orgId: string
+    orgId: string,
+    user: user
   ): Promise<string> {
-    const payload = { orgId };
+    const payload = { orgId, user };
 
     return this.sendNatsMessage(this.serviceProxy, 'delete-org-client-credentials', payload);
   }

--- a/apps/api-gateway/src/user/dto/add-user.dto.ts
+++ b/apps/api-gateway/src/user/dto/add-user.dto.ts
@@ -35,16 +35,6 @@ export class AddUserDetailsDto {
     @IsOptional()
     @IsBoolean({ message: 'isPasskey should be boolean' })
     isPasskey?: boolean;
-
-    @ApiProperty({ example: '6d69e2e1-a021-4ea5-a1bc-d8b40989d6fb' })
-    @IsOptional()
-    @IsString({ message: 'clientId should be string' })
-    clientId?: string;
-
-    @ApiProperty({ example: 'xxxx-xxxxx-xxxxx' })
-    @IsOptional()
-    @IsString({ message: 'clientSecret should be string' })
-    clientSecret?: string;
 }
 
 export class AddPasskeyDetailsDto {

--- a/apps/api-gateway/src/user/dto/add-user.dto.ts
+++ b/apps/api-gateway/src/user/dto/add-user.dto.ts
@@ -35,6 +35,16 @@ export class AddUserDetailsDto {
     @IsOptional()
     @IsBoolean({ message: 'isPasskey should be boolean' })
     isPasskey?: boolean;
+
+    @ApiProperty({ example: '6d69e2e1-a021-4ea5-a1bc-d8b40989d6fb' })
+    @IsOptional()
+    @IsString({ message: 'clientId should be string' })
+    clientId?: string;
+
+    @ApiProperty({ example: 'xxxx-xxxxx-xxxxx' })
+    @IsOptional()
+    @IsString({ message: 'clientSecret should be string' })
+    clientSecret?: string;
 }
 
 export class AddPasskeyDetailsDto {

--- a/apps/api-gateway/src/user/dto/create-user.dto.ts
+++ b/apps/api-gateway/src/user/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, MaxLength } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 import { toLowerCase, trim } from '@credebl/common/cast.helper';
 
 import { ApiProperty } from '@nestjs/swagger';
@@ -12,4 +12,12 @@ export class UserEmailVerificationDto {
     @MaxLength(256, { message: 'Email must be at most 256 character.' })
     @IsEmail({}, { message: 'Please provide a valid email' })
     email: string;
+
+    @ApiProperty({ example: 'xxxx-xxxx-xxxx' })
+    @IsString({ message: 'clientId should be string' })
+    clientId: string;
+
+    @ApiProperty({ example: 'xxxx-xxxxx-xxxxx' })
+    @IsString({ message: 'clientSecret should be string' })
+    clientSecret: string;
 }

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -3,7 +3,7 @@
 
 import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 // eslint-disable-next-line camelcase
-import { Prisma, agent_invitations, org_agents, org_invitations, user_org_roles } from '@prisma/client';
+import { Prisma, agent_invitations, org_agents, org_invitations, user, user_org_roles } from '@prisma/client';
 
 import { CreateOrganizationDto } from '../dtos/create-organization.dto';
 import { IDidDetails, IDidList, IGetOrgById, IGetOrganization, IPrimaryDidDetails, IUpdateOrganization } from '../interfaces/organization.interface';
@@ -379,6 +379,19 @@ export class OrganizationRepository {
       };
 
       return this.getOrgInvitationsPagination(query, pageNumber, pageSize);
+    } catch (error) {
+      this.logger.error(`error: ${JSON.stringify(error)}`);
+      throw new error;
+    }
+  }
+
+  async getUser(id: string): Promise<user> {
+    try {
+      const getUserById = await this.prisma.user.findUnique({ 
+        where:{
+          id
+      }});
+      return getUserById;
     } catch (error) {
       this.logger.error(`error: ${JSON.stringify(error)}`);
       throw new error;

--- a/apps/organization/src/organization.controller.ts
+++ b/apps/organization/src/organization.controller.ts
@@ -146,8 +146,8 @@ export class OrganizationController {
    */
 
   @MessagePattern({ cmd: 'get-org-roles' })
-  async getOrgRoles(payload: {orgId: string}): Promise<IClientRoles[]> {
-    return this.organizationService.getOrgRoles(payload.orgId);
+  async getOrgRoles(payload: {orgId: string, user: user}): Promise<IClientRoles[]> {
+    return this.organizationService.getOrgRoles(payload.orgId, payload.user);
   }
 
   @MessagePattern({ cmd: 'register-orgs-users-map' })
@@ -235,8 +235,8 @@ export class OrganizationController {
   }
 
   @MessagePattern({ cmd: 'delete-org-client-credentials' })
-  async deleteOrganizationCredentials(payload: { orgId: string }): Promise<string> {
-    return this.organizationService.deleteClientCredentials(payload.orgId);
+  async deleteOrganizationCredentials(payload: { orgId: string, user: user }): Promise<string> {
+    return this.organizationService.deleteClientCredentials(payload.orgId, payload.user);
   }
 
   @MessagePattern({ cmd: 'delete-organization-invitation' })

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -246,7 +246,9 @@ export class OrganizationService {
       let generatedClientSecret = '';
 
       if (organizationDetails.idpId) {
-        const token = await this.clientRegistrationService.getManagementToken();
+
+        const userDetails = await this.organizationRepository.getUser(userId);
+        const token = await this.clientRegistrationService.getManagementToken(userDetails.clientId, userDetails.clientSecret);
 
         generatedClientSecret = await this.clientRegistrationService.generateClientSecret(
           organizationDetails.idpId,
@@ -312,7 +314,8 @@ export class OrganizationService {
     userId: string,
     shouldUpdateRole: boolean
   ): Promise<IOrgCredentials> {
-    const token = await this.clientRegistrationService.getManagementToken();
+    const userDetails = await this.organizationRepository.getUser(userId);
+    const token = await this.clientRegistrationService.getManagementToken(userDetails.clientId, userDetails.clientSecret);
     const orgDetails = await this.clientRegistrationService.createClient(orgName, orgId, token);
 
     const orgRolesList = [OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER];
@@ -361,8 +364,8 @@ export class OrganizationService {
     return orgDetails;
   }
 
-  async deleteClientCredentials(orgId: string): Promise<string> {
-    const token = await this.clientRegistrationService.getManagementToken();
+  async deleteClientCredentials(orgId: string, user: user): Promise<string> {
+    const token = await this.clientRegistrationService.getManagementToken(user.clientId, user.clientSecret);
 
     const organizationDetails = await this.organizationRepository.getOrganizationDetails(orgId);
 
@@ -706,7 +709,7 @@ export class OrganizationService {
    * @returns organization roles
    */
 
-  async getOrgRoles(orgId: string): Promise<IClientRoles[]> {
+  async getOrgRoles(orgId: string, user: user): Promise<IClientRoles[]> {
     try {
       if (!orgId) {
         throw new BadRequestException(ResponseMessages.organisation.error.orgIdIsRequired);
@@ -722,7 +725,7 @@ export class OrganizationService {
         return this.orgRoleService.getOrgRoles();
       }
 
-      const token = await this.clientRegistrationService.getManagementToken();
+      const token = await this.clientRegistrationService.getManagementToken(user.clientId, user.clientSecret);
 
       return this.clientRegistrationService.getAllClientRoles(organizationDetails.idpId, token);
     } catch (error) {
@@ -814,7 +817,8 @@ export class OrganizationService {
     ): Promise<void> {
     const { invitations, orgId } = bulkInvitationDto;
 
-    const token = await this.clientRegistrationService.getManagementToken();
+    const userDetails = await this.organizationRepository.getUser(userId);
+    const token = await this.clientRegistrationService.getManagementToken(userDetails.clientId, userDetails.clientSecret);
     const clientRolesList = await this.clientRegistrationService.getAllClientRoles(idpId, token);
     const orgRoles = await this.orgRoleService.getOrgRoles();
 
@@ -1034,7 +1038,8 @@ export class OrganizationService {
     orgId: string,
     status: string
   ): Promise<void> {
-    const token = await this.clientRegistrationService.getManagementToken();
+    const userDetails = await this.organizationRepository.getUser(userId);
+    const token = await this.clientRegistrationService.getManagementToken(userDetails.clientId, userDetails.clientSecret);
       const clientRolesList = await this.clientRegistrationService.getAllClientRoles(idpId, token);
 
       const orgRoles = await this.orgRoleService.getOrgRolesByIds(invitation.orgRoles);
@@ -1139,7 +1144,8 @@ export class OrganizationService {
     userId: string,
     orgId: string
   ): Promise<boolean> {
-    const token = await this.clientRegistrationService.getManagementToken();
+    const userDetails = await this.organizationRepository.getUser(userId);
+    const token = await this.clientRegistrationService.getManagementToken(userDetails.clientId, userDetails.clientSecret);
     const clientRolesList = await this.clientRegistrationService.getAllClientRoles(
       idpId,
       token
@@ -1566,7 +1572,8 @@ export class OrganizationService {
 
           const usersToRegisterList = userOrgRoles.filter(userOrgRole => null !== userOrgRole.user.keycloakUserId);
           
-            const token = await this.clientRegistrationService.getManagementToken();
+            const userDetails = await this.organizationRepository.getUser(orgObj.ownerId);
+            const token = await this.clientRegistrationService.getManagementToken(userDetails.clientId, userDetails.clientSecret);
             const clientRolesList = await this.clientRegistrationService.getAllClientRoles(idpId, token);
 
             const deletedUserDetails: string[] = [];

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -1437,7 +1437,7 @@ export class OrganizationService {
     try {
       // Fetch token and organization details in parallel
       const [token, organizationDetails] = await Promise.all([
-        this.clientRegistrationService.getManagementToken(),
+        this.clientRegistrationService.getManagementToken(user.clientId, user.clientSecret),
         this.organizationRepository.getOrganizationDetails(orgId)
       ]);
   

--- a/apps/user/interfaces/user.interface.ts
+++ b/apps/user/interfaces/user.interface.ts
@@ -49,6 +49,8 @@ interface IUserOrgRole {
 export interface ISendVerificationEmail {
     email: string;
     username?: string;
+    clientId?: string;
+    clientSecret?: string;
   }
   
   export interface IUserInformation {
@@ -57,8 +59,6 @@ export interface ISendVerificationEmail {
     firstName: string;
     lastName: string;
     isPasskey: boolean;
-    clientId: string;
-    clientSecret: string;
   }
   
   export interface AddPasskeyDetails {

--- a/apps/user/interfaces/user.interface.ts
+++ b/apps/user/interfaces/user.interface.ts
@@ -57,6 +57,8 @@ export interface ISendVerificationEmail {
     firstName: string;
     lastName: string;
     isPasskey: boolean;
+    clientId: string;
+    clientSecret: string;
   }
   
   export interface AddPasskeyDetails {

--- a/apps/user/repositories/user.repository.ts
+++ b/apps/user/repositories/user.repository.ts
@@ -47,6 +47,8 @@ export class UserRepository {
           username: userEmailVerification.username,
           email: userEmailVerification.email,
           verificationCode: verifyCode.toString(),
+          clientId: userEmailVerification.clientId,
+          clientSecret: userEmailVerification.clientSecret,
           publicProfile: true
         },
         update: {
@@ -364,7 +366,7 @@ export class UserRepository {
    * @returns Updates organization details
    */
   // eslint-disable-next-line camelcase
-  async updateUserDetails(id: string, keycloakId: string, clientId: string, clientSecret: string): Promise<user> {
+  async updateUserDetails(id: string, keycloakId: string): Promise<user> {
     try {
       const updateUserDetails = await this.prisma.user.update({
         where: {
@@ -372,9 +374,7 @@ export class UserRepository {
         },
         data: {
           isEmailVerified: true,
-          keycloakUserId: keycloakId,
-          clientId,
-          clientSecret
+          keycloakUserId: keycloakId
         }
       });
       return updateUserDetails;

--- a/apps/user/repositories/user.repository.ts
+++ b/apps/user/repositories/user.repository.ts
@@ -364,7 +364,7 @@ export class UserRepository {
    * @returns Updates organization details
    */
   // eslint-disable-next-line camelcase
-  async updateUserDetails(id: string, keycloakId: string): Promise<user> {
+  async updateUserDetails(id: string, keycloakId: string, clientId: string, clientSecret: string): Promise<user> {
     try {
       const updateUserDetails = await this.prisma.user.update({
         where: {
@@ -372,7 +372,9 @@ export class UserRepository {
         },
         data: {
           isEmailVerified: true,
-          keycloakUserId: keycloakId
+          keycloakUserId: keycloakId,
+          clientId,
+          clientSecret
         }
       });
       return updateUserDetails;

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -116,7 +116,12 @@ export class UserService {
       const token = await this.clientRegistrationService.getManagementToken(resUser.clientId, resUser.clientSecret);
       const getClientData = await this.clientRegistrationService.getClientRedirectUrl(resUser.clientId, token);
       try {
-        const [redirectUrl] = getClientData[0].redirectUris;
+        const [redirectUrl] = getClientData[0]?.redirectUris;
+        
+        if (!redirectUrl) {
+          throw new NotFoundException(ResponseMessages.user.error.redirectUrlNotFound);
+        }
+
         await this.sendEmailForVerification(email, resUser.verificationCode, redirectUrl);
       } catch (error) {
         throw new InternalServerErrorException(ResponseMessages.user.error.emailSend);

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -116,7 +116,7 @@ export class UserService {
       const token = await this.clientRegistrationService.getManagementToken(resUser.clientId, resUser.clientSecret);
       const getClientData = await this.clientRegistrationService.getClientRedirectUrl(resUser.clientId, token);
       try {
-        const [redirectUrl] = getClientData[0]?.redirectUris;
+        const [redirectUrl] = getClientData[0]?.redirectUris || [];
         
         if (!redirectUrl) {
           throw new NotFoundException(ResponseMessages.user.error.redirectUrlNotFound);

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -122,7 +122,7 @@ export class UserService {
           throw new NotFoundException(ResponseMessages.user.error.redirectUrlNotFound);
         }
 
-        await this.sendEmailForVerification(email, resUser.verificationCode, redirectUrl);
+        await this.sendEmailForVerification(email, resUser.verificationCode, redirectUrl, resUser.clientId);
       } catch (error) {
         throw new InternalServerErrorException(ResponseMessages.user.error.emailSend);
       }
@@ -164,7 +164,7 @@ export class UserService {
    * @returns
    */
 
-  async sendEmailForVerification(email: string, verificationCode: string, redirectUrl: string): Promise<boolean> {
+  async sendEmailForVerification(email: string, verificationCode: string, redirectUrl: string, clientId: string): Promise<boolean> {
     try {
       const platformConfigData = await this.prisma.platform_config.findMany();
 
@@ -174,7 +174,7 @@ export class UserService {
       emailData.emailTo = email;
       emailData.emailSubject = `[${process.env.PLATFORM_NAME}] Verify your email to activate your account`;
 
-      emailData.emailHtml = await urlEmailTemplate.getUserURLTemplate(email, verificationCode, redirectUrl);
+      emailData.emailHtml = await urlEmailTemplate.getUserURLTemplate(email, verificationCode, redirectUrl, clientId);
       const isEmailSent = await sendEmail(emailData);
       if (isEmailSent) {
         return isEmailSent;

--- a/apps/user/templates/user-email-template.ts
+++ b/apps/user/templates/user-email-template.ts
@@ -11,7 +11,7 @@ export class URLUserEmailTemplate {
       
       validUrl = apiUrl.href.replace('/:', ':');
     } else {
-      validUrl = redirectUrl;
+      validUrl = `${redirectUrl}?verificationCode=${verificationCode}&email=${encodeURIComponent(email)}`;
     }
 
     try {

--- a/apps/user/templates/user-email-template.ts
+++ b/apps/user/templates/user-email-template.ts
@@ -1,13 +1,18 @@
 import * as url from 'url';
 export class URLUserEmailTemplate {
-  public getUserURLTemplate(email: string, verificationCode: string, redirectUrl: string): string {
+  public getUserURLTemplate(email: string, verificationCode: string, redirectUrl: string, clientId: string): string {
     // const endpoint = `${process.env.FRONT_END_URL}`;
 
-    const apiUrl = url.parse(
-      `${redirectUrl}/verify-email-success?verificationCode=${verificationCode}&email=${encodeURIComponent(email)}`
-    );
-    
-    const validUrl = apiUrl.href.replace('/:', ':');
+    let validUrl;
+    if (clientId === process.env.KEYCLOAK_MANAGEMENT_CLIENT_ID) {
+      const apiUrl = url.parse(
+        `${redirectUrl}/verify-email-success?verificationCode=${verificationCode}&email=${encodeURIComponent(email)}`
+      );
+      
+      validUrl = apiUrl.href.replace('/:', ':');
+    } else {
+      validUrl = redirectUrl;
+    }
 
     try {
       return `<!DOCTYPE html>

--- a/apps/user/templates/user-email-template.ts
+++ b/apps/user/templates/user-email-template.ts
@@ -1,10 +1,10 @@
 import * as url from 'url';
 export class URLUserEmailTemplate {
-  public getUserURLTemplate(email: string, verificationCode: string): string {
-    const endpoint = `${process.env.FRONT_END_URL}`;
+  public getUserURLTemplate(email: string, verificationCode: string, redirectUrl: string): string {
+    // const endpoint = `${process.env.FRONT_END_URL}`;
 
     const apiUrl = url.parse(
-      `${endpoint}/verify-email-success?verificationCode=${verificationCode}&email=${encodeURIComponent(email)}`
+      `${redirectUrl}/verify-email-success?verificationCode=${verificationCode}&email=${encodeURIComponent(email)}`
     );
     
     const validUrl = apiUrl.href.replace('/:', ':');

--- a/apps/user/templates/user-email-template.ts
+++ b/apps/user/templates/user-email-template.ts
@@ -1,18 +1,15 @@
-import * as url from 'url';
 export class URLUserEmailTemplate {
   public getUserURLTemplate(email: string, verificationCode: string, redirectUrl: string, clientId: string): string {
-    // const endpoint = `${process.env.FRONT_END_URL}`;
 
-    let validUrl;
-    if (clientId === process.env.KEYCLOAK_MANAGEMENT_CLIENT_ID) {
-      const apiUrl = url.parse(
-        `${redirectUrl}/verify-email-success?verificationCode=${verificationCode}&email=${encodeURIComponent(email)}`
-      );
-      
-      validUrl = apiUrl.href.replace('/:', ':');
-    } else {
-      validUrl = `${redirectUrl}?verificationCode=${verificationCode}&email=${encodeURIComponent(email)}`;
-    }
+    const apiUrl = new URL(
+      clientId === process.env.KEYCLOAK_MANAGEMENT_CLIENT_ID ? '/verify-email-success' : '',
+      redirectUrl
+    );
+
+    apiUrl.searchParams.append('verificationCode', verificationCode);
+    apiUrl.searchParams.append('email', encodeURIComponent(email));
+
+    const validUrl = apiUrl.href;
 
     try {
       return `<!DOCTYPE html>
@@ -64,7 +61,6 @@ export class URLUserEmailTemplate {
           </div>
       </body>
       </html>`;
-
     } catch (error) {}
   }
 }

--- a/libs/client-registration/src/client-registration.service.ts
+++ b/libs/client-registration/src/client-registration.service.ts
@@ -173,7 +173,7 @@ export class ClientRegistrationService {
     }
   }
 
-  async getManagementToken(clientId?: string, clientSecret?: string) {
+  async getManagementToken(clientId: string, clientSecret: string) {
     try {
       const payload = new ClientCredentialTokenPayloadDto();
       if (!clientId && !clientSecret) {
@@ -744,7 +744,7 @@ export class ClientRegistrationService {
   }
 
 
-  async getUserToken(email: string, password: string, clientId?: string, clientSecret?: string) {
+  async getUserToken(email: string, password: string, clientId: string, clientSecret: string) {
     try {
       const payload = new userTokenPayloadDto();
       if (!clientId && !clientSecret) {
@@ -788,7 +788,7 @@ export class ClientRegistrationService {
     }
   }
 
-  async getAccessToken(refreshToken: string, clientId?: string, clientSecret?: string) {
+  async getAccessToken(refreshToken: string, clientId: string, clientSecret: string) {
     try {
       const payload = new accessTokenPayloadDto();
       if (!clientId && !clientSecret) {

--- a/libs/client-registration/src/client-registration.service.ts
+++ b/libs/client-registration/src/client-registration.service.ts
@@ -172,13 +172,18 @@ export class ClientRegistrationService {
     }
   }
 
-  async getManagementToken() {
+  async getManagementToken(clientId?: string, clientSecret?: string) {
     try {
       const payload = new ClientCredentialTokenPayloadDto();
-      payload.client_id = process.env.KEYCLOAK_MANAGEMENT_CLIENT_ID;
-      payload.client_secret = process.env.KEYCLOAK_MANAGEMENT_CLIENT_SECRET;
-      const mgmtTokenResponse = await this.getToken(payload);
-      return mgmtTokenResponse.access_token;
+      if (clientId && clientSecret) {
+        payload.client_id = clientId;
+        payload.client_secret = clientSecret;
+      } else {
+        payload.client_id = process.env.KEYCLOAK_MANAGEMENT_CLIENT_ID;
+        payload.client_secret = process.env.KEYCLOAK_MANAGEMENT_CLIENT_SECRET;
+        }
+        const mgmtTokenResponse = await this.getToken(payload);
+        return mgmtTokenResponse.access_token;
     } catch (error) {
       this.logger.error(`Error in getManagementToken: ${JSON.stringify(error)}`);
 
@@ -200,7 +205,6 @@ export class ClientRegistrationService {
           mgmtTokenResponse
         )}`
       );
-      //return mgmtTokenResponse;
       return mgmtTokenResponse;
     } catch (error) {
 
@@ -738,11 +742,18 @@ export class ClientRegistrationService {
   }
 
 
-  async getUserToken(email: string, password: string) {
+  async getUserToken(email: string, password: string, clientId?: string, clientSecret?: string) {
     try {
       const payload = new userTokenPayloadDto();
-      payload.client_id = process.env.KEYCLOAK_MANAGEMENT_CLIENT_ID;
-      payload.client_secret = process.env.KEYCLOAK_MANAGEMENT_CLIENT_SECRET;
+      if (clientId && clientSecret) {
+
+        payload.client_id = clientId;
+        payload.client_secret = clientSecret;
+      } else {
+        payload.client_id = process.env.KEYCLOAK_MANAGEMENT_CLIENT_ID;
+        payload.client_secret = process.env.KEYCLOAK_MANAGEMENT_CLIENT_SECRET;
+      }
+
       payload.username = email;
       payload.password = password;
 
@@ -778,13 +789,20 @@ export class ClientRegistrationService {
     }
   }
 
-  async getAccessToken(refreshToken: string) {
+  async getAccessToken(refreshToken: string, clientId?: string, clientSecret?: string) {
     try {
       const payload = new accessTokenPayloadDto();
+      if (clientId && clientSecret) {
+
+        payload.client_id = clientId;
+        payload.client_secret = clientSecret;
+      } else {
+        payload.client_id = process.env.KEYCLOAK_MANAGEMENT_CLIENT_ID;
+        payload.client_secret = process.env.KEYCLOAK_MANAGEMENT_CLIENT_SECRET;
+      }
+
       payload.grant_type = 'refresh_token';
-      payload.client_id = process.env.KEYCLOAK_MANAGEMENT_CLIENT_ID;
       payload.refresh_token = refreshToken;
-      payload.client_secret = process.env.KEYCLOAK_MANAGEMENT_CLIENT_SECRET;
 
       if (
         'refresh_token' !== payload.grant_type ||

--- a/libs/common/src/interfaces/user.interface.ts
+++ b/libs/common/src/interfaces/user.interface.ts
@@ -12,6 +12,8 @@ export interface ISignInUser {
       }
       export interface ISendVerificationEmail {
         email: string;
+        clientId?: string;
+        clientSecret?: string;
         username?: string;
       }
       

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -35,6 +35,7 @@ export const ResponseMessages = {
             notUpdateEcosystemSettings: 'Unable to update ecosystem config settings',
             verificationAlreadySent: 'The verification link has already been sent to your email address',
             emailSend: 'Unable to send email to the user',
+            redirectUrlNotFound: 'Redirect URL not found',
             invalidEmailUrl: 'Invalid verification code or EmailId!',
             verifiedEmail: 'Email already verified',
             notFound: 'User not found',


### PR DESCRIPTION
### What ###

- Adding new columns to the user table for storing Keycloak clientId and client secret.
- Implementing the logic to update and retrieve these values when creating or updating a user.
- Modifying the necessary services and controllers to handle the new fields.

### Why ###

- Managing Keycloak clientId and client secret directly on the user table is necessary to:
  Simplify the integration between our application and Keycloak by having the authentication details directly associated with the user.

### How ###
#### Service and Controller Updates: ####

- Update user creation and update services to include ClientId and Client Secret fields.
- Modify the relevant controllers to accept and process these fields in user-related requests.