### PR TITLE
feat: send email for delete organization invitations

### DIFF
--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -542,7 +542,7 @@ export class OrganizationController {
   @ApiOperation({ summary: 'Delete Organization', description: 'Delete an organization' })
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   @ApiBearerAuth()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   @Roles(OrgRoles.OWNER)
   async deleteOrganization(
     @Param('orgId', TrimStringParamPipe, new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, 

--- a/apps/organization/interfaces/organization.interface.ts
+++ b/apps/organization/interfaces/organization.interface.ts
@@ -233,3 +233,14 @@ export interface ILedgerDetails {
   networkUrl: string;
 
 }
+
+export interface IOrgRoleDetails {
+  id: string;
+  name: string;
+  description: string;
+  createDateTime: Date;
+  createdBy: string;
+  lastChangedDateTime: Date;
+  lastChangedBy: string;
+  deletedAt: Date;
+}

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -6,7 +6,7 @@ import { ConflictException, Injectable, Logger, NotFoundException } from '@nestj
 import { Prisma, agent_invitations, org_agents, org_invitations, user, user_org_roles } from '@prisma/client';
 
 import { CreateOrganizationDto } from '../dtos/create-organization.dto';
-import { IGetDids, IDidDetails, IDidList, IGetOrgById, IGetOrganization, IPrimaryDidDetails, IUpdateOrganization, ILedgerNameSpace, OrgInvitation, ILedgerDetails } from '../interfaces/organization.interface';
+import { IGetDids, IDidDetails, IDidList, IGetOrgById, IGetOrganization, IPrimaryDidDetails, IUpdateOrganization, ILedgerNameSpace, OrgInvitation, ILedgerDetails, IOrgRoleDetails } from '../interfaces/organization.interface';
 import { InternalServerErrorException } from '@nestjs/common';
 import { Invitation, PrismaTables, SortValue } from '@credebl/enum/enum';
 import { PrismaService } from '@credebl/prisma-service';
@@ -827,6 +827,7 @@ export class OrganizationRepository {
 
             return {deletedUserActivity, deletedUserOrgRole, deletedOrgInvitations, deleteOrg};
         });
+        // return result;
     } catch (error) {
         this.logger.error(`Error in deleteOrg: ${error}`);
         throw error;
@@ -994,6 +995,43 @@ async getDidDetailsByDid(did:string): Promise<IDidDetails> {
     return ledgerData;
   } catch (error) {
     this.logger.error(`[getLedger] - get ledger details: ${JSON.stringify(error)}`);
+    throw error;
+  }
+}
+
+async getOrgRole(id: string[]): Promise<IOrgRoleDetails[]> {
+  try {
+    const orgRoleData = await this.prisma.org_roles.findMany({
+      where: {
+        id: {
+            in: id
+        }
+    }
+    });
+    return orgRoleData;
+  } catch (error) {
+    this.logger.error(`[getOrgRole] - get org role details: ${JSON.stringify(error)}`);
+    throw error;
+  }
+}
+
+async getUserOrgRole(userId: string, orgId: string): Promise<string[]> {
+  try {
+    const userOrgRoleDetails = await this.prisma.user_org_roles.findMany({
+      where: {
+        userId,
+        orgId
+    },
+    select:{
+      orgRoleId: true
+    }
+    });
+     // Map the result to an array of orgRoleId
+     const orgRoleIds = userOrgRoleDetails.map(role => role.orgRoleId);
+
+     return orgRoleIds;
+  } catch (error) {
+    this.logger.error(`[getUserOrgRole] - get user org role details: ${JSON.stringify(error)}`);
     throw error;
   }
 }

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -764,6 +764,7 @@ export class OrganizationRepository {
     deletedUserActivity: Prisma.BatchPayload;
     deletedUserOrgRole: Prisma.BatchPayload;
     deletedOrgInvitations: Prisma.BatchPayload;
+    deletedNotification: Prisma.BatchPayload;
     deleteOrg: IDeleteOrganization
   }> {
     const tablesToCheck = [
@@ -775,8 +776,7 @@ export class OrganizationRepository {
         `${PrismaTables.PRESENTATIONS}`,
         `${PrismaTables.ECOSYSTEM_INVITATIONS}`,
         `${PrismaTables.ECOSYSTEM_ORGS}`,
-        `${PrismaTables.FILE_UPLOAD}`,
-        `${PrismaTables.NOTIFICATION}`
+        `${PrismaTables.FILE_UPLOAD}`
     ];
 
     try {
@@ -806,6 +806,8 @@ export class OrganizationRepository {
                 throw new ConflictException(ResponseMessages.organisation.error.organizationEcosystemValidate);
             }
 
+            const deletedNotification = await prisma.notification.deleteMany({ where: { orgId: id } });
+
             const deletedUserActivity = await prisma.user_activity.deleteMany({ where: { orgId: id } });
 
             const deletedUserOrgRole = await prisma.user_org_roles.deleteMany({ where: { orgId: id } });
@@ -825,7 +827,7 @@ export class OrganizationRepository {
             // If no references are found, delete the organization
             const deleteOrg = await prisma.organisation.delete({ where: { id } });
 
-            return {deletedUserActivity, deletedUserOrgRole, deletedOrgInvitations, deleteOrg};
+            return {deletedUserActivity, deletedUserOrgRole, deletedOrgInvitations, deletedNotification, deleteOrg};
         });
         // return result;
     } catch (error) {

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -26,7 +26,7 @@ import { sendEmail } from '@credebl/common/send-grid-helper-file';
 import { CreateOrganizationDto } from '../dtos/create-organization.dto';
 import { BulkSendInvitationDto } from '../dtos/send-invitation.dto';
 import { UpdateInvitationDto } from '../dtos/update-invitation.dt';
-import { DidMethod, Invitation, Ledgers, transition } from '@credebl/enum/enum';
+import { DidMethod, Invitation, Ledgers, PrismaTables, transition } from '@credebl/enum/enum';
 import { IGetOrgById, IGetOrganization, IUpdateOrganization, IOrgAgent, IClientCredentials, ICreateConnectionUrl, IOrgRole, IDidList, IPrimaryDidDetails } from '../interfaces/organization.interface';
 import { UserActivityService } from '@credebl/user-activity';
 import { ClientRegistrationService } from '@credebl/client-registration/client-registration.service';
@@ -1520,8 +1520,9 @@ export class OrganizationService {
         throw new NotFoundException(ResponseMessages.organisation.error.orgDataNotFoundInkeycloak);
       }
   
+      const deletedOrgInvitationInfo: { email?: string, orgName?: string, orgRoleNames?: string[] }[] = [];
       const userIds = (await this.getUserKeycloakIdByEmail(arrayEmail)).response.map(user => user.id);
-      userIds.map(async (userId) => {
+      await Promise.all(userIds.map(async (userId) => {
         const userOrgRoleIds = await this.organizationRepository.getUserOrgRole(userId, orgId);
         this.logger.debug(`userOrgRoleIds ::::: ${JSON.stringify(userOrgRoleIds)}`);
 
@@ -1533,11 +1534,20 @@ export class OrganizationService {
         
         const orgRoleNames = orgRoles.map(orgRoleName => orgRoleName.name);
         const sendEmail = await this.sendEmailForOrgInvitationsMember(userDetails?.email, organizationDetails?.name, orgRoleNames);
+        const newInvitation = {
+          email: userDetails.email,
+          orgName: organizationDetails?.name,
+          orgRoleNames
+        };
+        
+        // Step 3: Push the data into the array
+        deletedOrgInvitationInfo.push(newInvitation);
+        
         this.logger.log(`email: ${userDetails.email}, orgName: ${organizationDetails?.name}, orgRoles: ${JSON.stringify(orgRoleNames)}, sendEmail: ${sendEmail}`);
-      });
+      }));
       
       // Delete organization data
-      const { deletedUserActivity, deletedUserOrgRole, deleteOrg, deletedOrgInvitations } = await this.organizationRepository.deleteOrg(orgId);
+      const { deletedUserActivity, deletedUserOrgRole, deleteOrg, deletedOrgInvitations, deletedNotification } = await this.organizationRepository.deleteOrg(orgId);
   
       this.logger.debug(`deletedUserActivity ::: ${JSON.stringify(deletedUserActivity)}`);
       this.logger.debug(`deletedUserOrgRole ::: ${JSON.stringify(deletedUserOrgRole)}`);
@@ -1545,19 +1555,29 @@ export class OrganizationService {
       this.logger.debug(`deletedOrgInvitations ::: ${JSON.stringify(deletedOrgInvitations)}`);
   
       const deletions = [
-        { records: deletedUserActivity.count, tableName: 'user_activity' },
-        { records: deletedUserOrgRole.count, tableName: 'user_org_roles' },
-        { records: deletedOrgInvitations.count, tableName: 'org_invitations' },
-        { records: deleteOrg ? 1 : 0, tableName: 'organization' }
+        { records: deletedUserActivity.count, tableName: `${PrismaTables.USER_ACTIVITY}` },
+        { records: deletedUserOrgRole.count, tableName: `${PrismaTables.USER_ORG_ROLES}` },
+        { records: deletedOrgInvitations.count, deletedOrgInvitationInfo, tableName: `${PrismaTables.ORG_INVITATIONS}` },
+        { records: deletedNotification.count, tableName: `${PrismaTables.NOTIFICATION}` },
+        { records: deleteOrg ? 1 : 0, tableName: `${PrismaTables.ORGANIZATION}` }
       ];
   
       // Log deletion activities in parallel
-      await Promise.all(deletions.map(async ({ records, tableName }) => {
+      await Promise.all(deletions.map(async ({ records, tableName, deletedOrgInvitationInfo }) => {
         if (records) {
-          const txnMetadata = {
+          const txnMetadata: {
+            deletedRecordsCount: number;
+            deletedRecordInTable: string;
+            deletedOrgInvitationInfo?: object[]
+          } = {
             deletedRecordsCount: records,
             deletedRecordInTable: tableName
           };
+          
+          if (deletedOrgInvitationInfo) {
+            txnMetadata.deletedOrgInvitationInfo = deletedOrgInvitationInfo;
+          }
+          
           const recordType = RecordType.ORGANIZATION;
           await this.userActivityRepository._orgDeletedActivity(orgId, user, txnMetadata, recordType);
         }

--- a/apps/organization/templates/delete-organization-invitations.template.ts
+++ b/apps/organization/templates/delete-organization-invitations.template.ts
@@ -1,0 +1,51 @@
+export class DeleteOrgInvitationsEmail {
+
+    public sendDeleteOrgMemberEmailTemplate(
+        email: string,
+        orgName: string,
+        orgRoles: string[]
+    ): string {
+          
+    const orgRoleNames = 0 < orgRoles.length ? orgRoles.join(', ') : '';
+    return `<!DOCTYPE html>
+        <html lang="en">
+        
+        <head>  
+            <title></title>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+        </head>
+        
+        <body style="margin: 0px; padding:0px; background-color:#F9F9F9;">
+            <div style="margin: auto; max-width: 450px; padding: 20px 30px; background-color: #FFFFFF; display:block;">
+          <div style="display: block; text-align:center; background-color: white; padding-bottom: 20px; padding-top: 20px;">
+              <img src="${process.env.BRAND_LOGO}" alt="${process.env.PLATFORM_NAME} logo" style="max-width:100px; background: white; padding: 5px;border-radius: 5px;" width="100%" height="fit-content" class="CToWUd" data-bit="iit">
+          </div>
+          
+        <div style="font-family: Montserrat; font-style: normal; font-weight: 500;
+          font-size: 15px; line-height: 24px;color: #00000;">
+              <p style="margin-top:0px">
+                  Hello ${email},
+              </p>
+              <p>
+              We would like to inform you that the organization “${orgName}” has removed their participation as a ${orgRoleNames} on CREDEBL.
+
+              <hr style="border-top:1px solid #e8e8e8" />
+              <footer style="padding-top: 10px;">
+                  <div style="font-style: italic; color: #777777">
+                      For any assistance or questions while accessing your account, please do not hesitate to contact the support team at ${process.env.PUBLIC_PLATFORM_SUPPORT_EMAIL}.
+                  </div>
+                  <p style="margin-top: 6px;">
+                     © ${process.env.POWERED_BY}
+                  </p>
+              </footer>
+          </div>
+      </div>
+        </body>
+        
+        </html>`;
+
+    }
+
+
+}

--- a/apps/user/interfaces/user.interface.ts
+++ b/apps/user/interfaces/user.interface.ts
@@ -215,3 +215,9 @@ export interface IUserDeletedActivity {
   deletedBy: string;
   deleteDateTime: Date;
 }
+
+export interface UserKeycloakId {
+  id: string;
+  keycloakUserId: string;
+  email: string;
+}

--- a/apps/user/repositories/user.repository.ts
+++ b/apps/user/repositories/user.repository.ts
@@ -11,7 +11,8 @@ import {
   IUsersProfile,
   IUserInformation,
   IVerifyUserEmail,
-  IUserDeletedActivity
+  IUserDeletedActivity,
+  UserKeycloakId
 } from '../interfaces/user.interface';
 import { InternalServerErrorException } from '@nestjs/common';
 import { PrismaService } from '@credebl/prisma-service';
@@ -798,30 +799,35 @@ export class UserRepository {
     }
   }
 
-  async getUserKeycloak(userEmails: string[]): Promise<string[]> {
+  async getUserKeycloak(userEmails: string[]): Promise<UserKeycloakId[]> {
     try {
       const users = await this.prisma.user.findMany({
         where: {
-            email: {
-                in: userEmails
-            }
+          email: {
+            in: userEmails
+          }
         },
         select: {
-            email: true,
-            keycloakUserId: true
+          email: true,
+          keycloakUserId: true,
+          id: true
         }
-    });
-
-    // Create a map for quick lookup of keycloakUserId by email
-    const userMap = new Map(users.map(user => [user.email, user.keycloakUserId]));
-
-    // Collect the keycloakUserIds in the order of input emails
-    const keycloakUserIds = userEmails.map(email => userMap.get(email) || null);
-
-    return keycloakUserIds;
+      });
+  
+      // Create a map for quick lookup of keycloakUserId, id, and email by email
+      const userMap = new Map(users.map(user => [user.email, { id: user.id, keycloakUserId: user.keycloakUserId, email: user.email }]));
+  
+      // Collect the keycloakUserId, id, and email in the order of input emails
+      const result = userEmails.map(email => {
+        const user = userMap.get(email);
+        return { id: user?.id || null, keycloakUserId: user?.keycloakUserId || null, email };
+      });
+  
+      return result;
     } catch (error) {
-      this.logger.error(`Error in getUserKeycloak: ${error} `);
+      this.logger.error(`Error in getUserKeycloak: ${error}`);
       throw error;
     }
   }
+  
 }

--- a/apps/user/src/user.controller.ts
+++ b/apps/user/src/user.controller.ts
@@ -1,4 +1,4 @@
-import { IOrgUsers, Payload, ICheckUserDetails, PlatformSettings, IShareUserCertificate, UpdateUserProfile, IUsersProfile, IUserInformation, IUserSignIn, IUserCredentials, IUserResetPassword, IUserDeletedActivity} from '../interfaces/user.interface';
+import { IOrgUsers, Payload, ICheckUserDetails, PlatformSettings, IShareUserCertificate, UpdateUserProfile, IUsersProfile, IUserInformation, IUserSignIn, IUserCredentials, IUserResetPassword, IUserDeletedActivity, UserKeycloakId} from '../interfaces/user.interface';
 import { AcceptRejectInvitationDto } from '../dtos/accept-reject-invitation.dto';
 import { Controller } from '@nestjs/common';
 import { MessagePattern } from '@nestjs/microservices';
@@ -216,7 +216,7 @@ export class UserController {
   }
 
   @MessagePattern({ cmd: 'get-user-keycloak-id' })
-  async getUserKeycloakIdByEmail(userEmails: string[]): Promise<string[]> {
+  async getUserKeycloakIdByEmail(userEmails: string[]): Promise<UserKeycloakId[]> {
     return this.userService.getUserKeycloakIdByEmail(userEmails);
   }
 

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -41,7 +41,8 @@ import {
     IUserResetPassword,
     IPuppeteerOption,
     IShareDegreeCertificateRes,
-    IUserDeletedActivity
+    IUserDeletedActivity,
+    UserKeycloakId
 } from '../interfaces/user.interface';
 import { AcceptRejectInvitationDto } from '../dtos/accept-reject-invitation.dto';
 import { UserActivityService } from '@credebl/user-activity';
@@ -1176,7 +1177,7 @@ export class UserService {
     }
   }
 
-  async getUserKeycloakIdByEmail(userEmails: string[]): Promise<string[]> {
+  async getUserKeycloakIdByEmail(userEmails: string[]): Promise<UserKeycloakId[]> {
     try {
      
       const getkeycloakUserIds = await this.userRepository.getUserKeycloak(userEmails);

--- a/libs/client-registration/src/client-registration.service.ts
+++ b/libs/client-registration/src/client-registration.service.ts
@@ -177,7 +177,8 @@ export class ClientRegistrationService {
     try {
       const payload = new ClientCredentialTokenPayloadDto();
       if (!clientId && !clientSecret) {
-        throw new BadRequestException(`Client ID and client secret are missing`);
+        this.logger.error(`getManagementToken ::: Client ID and client secret are missing`);
+        throw new BadRequestException(`Client ID and client secret are missing 3`);
       } 
 
       payload.client_id = clientId;
@@ -748,7 +749,8 @@ export class ClientRegistrationService {
     try {
       const payload = new userTokenPayloadDto();
       if (!clientId && !clientSecret) {
-        throw new BadRequestException(`Client ID and client secret are missing`);
+        this.logger.error(`getUserToken ::: Client ID and client secret are missing`);
+        throw new BadRequestException(`Client ID and client secret are missing 2`);
       } 
       
       payload.client_id = clientId;
@@ -792,7 +794,8 @@ export class ClientRegistrationService {
     try {
       const payload = new accessTokenPayloadDto();
       if (!clientId && !clientSecret) {
-        throw new BadRequestException(`Client ID and client secret are missing`);
+        this.logger.error(`getAccessToken ::: Client ID and client secret are missing`);
+        throw new BadRequestException(`Client ID and client secret are missing 1`);
       } 
 
       payload.client_id = clientId;

--- a/libs/client-registration/src/client-registration.service.ts
+++ b/libs/client-registration/src/client-registration.service.ts
@@ -178,7 +178,7 @@ export class ClientRegistrationService {
       const payload = new ClientCredentialTokenPayloadDto();
       if (!clientId && !clientSecret) {
         this.logger.error(`getManagementToken ::: Client ID and client secret are missing`);
-        throw new BadRequestException(`Client ID and client secret are missing 3`);
+        throw new BadRequestException(`Client ID and client secret are missing`);
       } 
 
       payload.client_id = clientId;
@@ -750,7 +750,7 @@ export class ClientRegistrationService {
       const payload = new userTokenPayloadDto();
       if (!clientId && !clientSecret) {
         this.logger.error(`getUserToken ::: Client ID and client secret are missing`);
-        throw new BadRequestException(`Client ID and client secret are missing 2`);
+        throw new BadRequestException(`Client ID and client secret are missing`);
       } 
       
       payload.client_id = clientId;
@@ -795,7 +795,7 @@ export class ClientRegistrationService {
       const payload = new accessTokenPayloadDto();
       if (!clientId && !clientSecret) {
         this.logger.error(`getAccessToken ::: Client ID and client secret are missing`);
-        throw new BadRequestException(`Client ID and client secret are missing 1`);
+        throw new BadRequestException(`Client ID and client secret are missing`);
       } 
 
       payload.client_id = clientId;

--- a/libs/enum/src/enum.ts
+++ b/libs/enum/src/enum.ts
@@ -158,6 +158,10 @@ export enum PrismaTables {
     ECOSYSTEM_INVITATIONS = 'ecosystem_invitations',
     FILE_UPLOAD = 'file_upload',
     NOTIFICATION = 'notification',
+    USER_ACTIVITY = 'user_activity',
+    USER_ORG_ROLES = 'user_org_roles',
+    ORG_INVITATIONS = 'org_invitations',
+    ORGANIZATION = 'organization'
 }
 
 export enum IssuanceProcessState {


### PR DESCRIPTION
### What ###
- Added functionality to send an email notification when an organization invitation is deleted.

### Why ###
- To ensure that both the inviter and invitee are informed about the deletion of the invitation.

### How ###
- Implemented a service to handle email notifications specifically for deleted invitations.
- Updated the orgController to trigger the email notification upon deletion of an invitation.
- Updated email templates to include relevant information about the deleted invitation.