### PR TITLE
feat:refactored `retry-bulk-credentials` api to add dynamic support to email template

### DIFF
--- a/apps/api-gateway/src/issuance/issuance.controller.ts
+++ b/apps/api-gateway/src/issuance/issuance.controller.ts
@@ -537,7 +537,7 @@ async downloadBulkIssuanceCSVTemplate(
     const bulkIssuanceDetails = await this.issueCredentialService.retryBulkCredential(
       fileId,
       orgId,
-      clientDetails.clientId
+      clientDetails
     );
     const finalResponse: IResponseType = {
       statusCode: HttpStatus.CREATED,

--- a/apps/api-gateway/src/issuance/issuance.service.ts
+++ b/apps/api-gateway/src/issuance/issuance.service.ts
@@ -124,8 +124,8 @@ export class IssuanceService extends BaseService {
         return this.sendNatsMessage(this.issuanceProxy, 'issue-bulk-credentials', payload);
     }
 
-    async retryBulkCredential(fileId: string, orgId: string, clientId: string): Promise<{ response: object }> {
-        const payload = { fileId, orgId, clientId };
+    async retryBulkCredential(fileId: string, orgId: string, clientDetails: ClientDetails): Promise<{ response: object }> {
+        const payload = { fileId, orgId, clientDetails };
         return this.sendNats(this.issuanceProxy, 'retry-bulk-credentials', payload);
     }
 

--- a/apps/issuance/src/issuance.controller.ts
+++ b/apps/issuance/src/issuance.controller.ts
@@ -95,8 +95,8 @@ export class IssuanceController {
   }
 
   @MessagePattern({ cmd: 'retry-bulk-credentials' })
-  async retryeBulkCredentials(payload: { fileId: string, orgId: string, clientId: string }): Promise<string> {
-    return this.issuanceService.retryBulkCredential(payload.fileId, payload.orgId, payload.clientId);
+  async retryeBulkCredentials(payload: { fileId: string, orgId: string, clientDetails: IClientDetails }): Promise<string> {
+    return this.issuanceService.retryBulkCredential(payload.fileId, payload.orgId, payload.clientDetails);
   }
 
   @MessagePattern({ cmd: 'delete-issuance-records' })

--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -1407,7 +1407,7 @@ async sendEmailForCredentialOffer(sendEmailCredentialOffer: SendEmailCredentialO
     }
   }
 
-  async retryBulkCredential(fileId: string, orgId: string, clientId: string): Promise<string> {
+  async retryBulkCredential(fileId: string, orgId: string, clientDetails: IClientDetails): Promise<string> {
     let bulkpayloadRetry;
     try {
       const fileDetails = await this.issuanceRepository.getFileDetailsById(fileId);
@@ -1422,9 +1422,11 @@ async sendEmailForCredentialOffer(sendEmailCredentialOffer: SendEmailCredentialO
       
       try {
         const bulkPayloadDetails: BulkPayloadDetails = {
-          clientId,
+          clientId : clientDetails.clientId,
           orgId,
-          isRetry: true
+          isRetry: true,
+          organizationLogoUrl: clientDetails?.organizationLogoUrl,
+          platformName: clientDetails?.platformName
         };
         this.processInBatches(bulkpayloadRetry, bulkPayloadDetails);
        } catch (error) {


### PR DESCRIPTION
### What ###

- Added 'organizationLogoUrl' and 'platformName' in request parameter for issue-bulk-credentials API.

- Refactored retry-bulk-credentials API for issuance.

### Why ###

- While issuing credentials for user need to send issuance email which is specific to organisation.