### PR TITLE
refactor: store holder role in user role mapping table

### DIFF
--- a/apps/user/interfaces/user.interface.ts
+++ b/apps/user/interfaces/user.interface.ts
@@ -1,4 +1,4 @@
-import { Prisma, RecordType } from '@prisma/client';
+import { $Enums, Prisma, RecordType } from '@prisma/client';
 
 export interface IUsersProfile {
   id: string;
@@ -223,4 +223,15 @@ export interface UserKeycloakId {
   id: string;
   keycloakUserId: string;
   email: string;
+}
+
+export interface UserRoleMapping {
+  id: string;
+  userId: string;
+  userRoleId: string;
+}
+
+export interface UserRoleDetails{
+  id: string;
+  role: $Enums.UserRole;
 }

--- a/apps/user/repositories/user.repository.ts
+++ b/apps/user/repositories/user.repository.ts
@@ -12,12 +12,15 @@ import {
   IUserInformation,
   IVerifyUserEmail,
   IUserDeletedActivity,
-  UserKeycloakId
+  UserKeycloakId,
+  UserRoleMapping,
+  UserRoleDetails
 } from '../interfaces/user.interface';
 import { InternalServerErrorException } from '@nestjs/common';
 import { PrismaService } from '@credebl/prisma-service';
 // eslint-disable-next-line camelcase
 import { RecordType, schema, token, user } from '@prisma/client';
+import { UserRole } from '@credebl/enum/enum';
 
 interface UserQueryOptions {
   id?: string; // Use the appropriate type based on your data model
@@ -836,4 +839,32 @@ export class UserRepository {
     }
   }
   
+  async storeUserRole(userId: string, userRoleId: string): Promise<UserRoleMapping> {
+    try {
+      const userRoleMapping = await this.prisma.user_role_mapping.create({
+        data: {
+          userId,
+          userRoleId
+        }
+      });
+      return userRoleMapping;
+    } catch (error) {
+      this.logger.error(`Error in storeUserRole: ${error.message} `);
+      throw error;
+    }
+  }
+
+  async getUserRole(role: UserRole): Promise<UserRoleDetails> {
+    try {
+      const getUserRole = await this.prisma.user_role.findFirstOrThrow({
+        where: {
+          role
+        }
+      });
+      return getUserRole;
+    } catch (error) {
+      this.logger.error(`Error in getUserRole: ${error.message} `);
+      throw error;
+    }
+  }
 }

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -49,7 +49,7 @@ import { UserActivityService } from '@credebl/user-activity';
 import { SupabaseService } from '@credebl/supabase';
 import { UserDevicesRepository } from '../repositories/user-device.repository';
 import { v4 as uuidv4 } from 'uuid';
-import { EcosystemConfigSettings, Invitation, UserCertificateId } from '@credebl/enum/enum';
+import { EcosystemConfigSettings, Invitation, UserCertificateId, UserRole } from '@credebl/enum/enum';
 import { WinnerTemplate } from '../templates/winner-template';
 import { ParticipantTemplate } from '../templates/participant-template';
 import { ArbiterTemplate } from '../templates/arbiter-template';
@@ -252,10 +252,9 @@ export class UserService {
       if (!userDetails) {
         throw new NotFoundException(ResponseMessages.user.error.adduser);
       }
-
-      let keycloakDetails = null;
-
-      const token = await this.clientRegistrationService.getManagementToken(checkUserDetails.clientId, checkUserDetails.clientSecret);
+   let keycloakDetails = null;
+      
+   const token = await this.clientRegistrationService.getManagementToken(checkUserDetails.clientId, checkUserDetails.clientSecret);
       if (userInfo.isPasskey) {
         const resUser = await this.userRepository.addUserPassword(email.toLowerCase(), userInfo.password);
         const userDetails = await this.userRepository.getUserDetails(email.toLowerCase());
@@ -286,6 +285,15 @@ export class UserService {
       await this.userRepository.updateUserDetails(userDetails.id,
         keycloakDetails.keycloakUserId.toString()
       );
+
+      if (userInfo?.isHolder) {
+        const getUserRole = await this.userRepository.getUserRole(UserRole.HOLDER);
+
+        if (!getUserRole) {
+          throw new NotFoundException(ResponseMessages.user.error.userRoleNotFound);
+        }
+        await this.userRepository.storeUserRole(userDetails.id, getUserRole?.id);
+      }
 
       const realmRoles = await this.clientRegistrationService.getAllRealmRoles(token);
       

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -51,6 +51,7 @@ export const ResponseMessages = {
       invalidKeycloakId: 'keycloakId is invalid',
       invalidEmail: 'Invalid Email Id!',
       adduser: 'Unable to add user details',
+      userRoleNotFound: 'User role not found',
       verifyEmail: 'The verification link has already been sent to your email address. please verify',
       emailNotVerified: 'The verification link has already been sent to your email address. please verify',
       userNotRegisterd: 'The user has not yet completed the registration process',

--- a/libs/enum/src/enum.ts
+++ b/libs/enum/src/enum.ts
@@ -245,4 +245,9 @@ export enum ledgerLessDIDType {
 export enum CloudWalletType {
     BASE_WALLET = 'CLOUD_BASE_WALLET',
     SUB_WALLET = 'CLOUD_SUB_WALLET'
-  }
+}
+
+export enum UserRole {
+    DEFAULT_USER = 'DEFAULT_USER',
+    HOLDER = 'HOLDER'
+}


### PR DESCRIPTION
### What ###
Refactor the code to store the holder role in the user role mapping table.

### Why ###
Storing the holder role in a dedicated user role mapping table enhances maintainability, scalability, and clarity in role management.

### How ###

- Created a new user role mapping table to store user roles.
- Updated the existing code to insert and retrieve holder roles from the new table.
- Modified related functions and queries to accommodate the new structure.
- Added necessary migrations to update the database schema.