### PR TITLE
fix: gracefully handle missing deeplink domain url from env

### DIFF
--- a/libs/common/src/common.utils.ts
+++ b/libs/common/src/common.utils.ts
@@ -1,4 +1,6 @@
+import { NotFoundException } from '@nestjs/common';
 import * as dotenv from 'dotenv';
+import { ResponseMessages } from './response-messages';
 dotenv.config();
 /* eslint-disable camelcase */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
@@ -49,7 +51,11 @@ export function orderValues(key, order = 'asc') {
 
 
 export function convertUrlToDeepLinkUrl(url: string): string {
-  const deepLinkUrl = (process.env.DEEPLINK_DOMAIN as string).concat(url);
+  const deepLinkDomain = process.env.DEEPLINK_DOMAIN
+  if(!deepLinkDomain) {
+    throw new NotFoundException(ResponseMessages.shorteningUrl.error.deepLinkDomainNotFound)
+  }
+  const deepLinkUrl = deepLinkDomain.concat(url);
   return deepLinkUrl;
 }
 

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -487,6 +487,9 @@ export const ResponseMessages = {
     success: {
       getshorteningUrl: 'Shortening Url fetched successfully',
       createShorteningUrl: 'Shortening Url created successfully'
+    },
+    error: {
+      deepLinkDomainNotFound: 'Deeplink Domain not found. Please make sure to add it in your environment variables'
     }
   },
   notification: {


### PR DESCRIPTION
# What:
- Gracefully handle missing environment variable for deeplink domain url

# Why:
- Currently with missing env variable, the exception results in unexpected errors