### PR TITLE
fix: solved the clientId dcryption in verification email

### DIFF
--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -177,6 +177,7 @@ export class UserService {
     try {
       const platformConfigData = await this.prisma.platform_config.findMany();
 
+      const decryptClientId = await this.commonService.decryptPassword(clientId);
       const urlEmailTemplate = new URLUserEmailTemplate();
       const emailData = new EmailDto();
       emailData.emailFrom = platformConfigData[0].emailFrom;
@@ -184,7 +185,7 @@ export class UserService {
       const platform = platformName || process.env.PLATFORM_NAME;
       emailData.emailSubject = `[${platform}] Verify your email to activate your account`;
 
-      emailData.emailHtml = await urlEmailTemplate.getUserURLTemplate(email, verificationCode, redirectUrl, clientId, brandLogoUrl, platformName);
+      emailData.emailHtml = await urlEmailTemplate.getUserURLTemplate(email, verificationCode, redirectUrl, decryptClientId, brandLogoUrl, platformName);
       const isEmailSent = await sendEmail(emailData);
       if (isEmailSent) {
         return isEmailSent;


### PR DESCRIPTION
### What ###

- fix the dcryption clientId in the verification

 ### Why ###
 
 - To check the clientId for redirect URL to verify the email