### PR TITLE
fix: schema search during pagination

### DIFF
--- a/libs/prisma-service/prisma/seed.ts
+++ b/libs/prisma-service/prisma/seed.ts
@@ -409,9 +409,13 @@ const migrateOrgAgentDids = async (): Promise<void> => {
             }
         });
 
+        const filteredOrgAgents = orgAgents.filter(
+            (agent) => null !== agent.orgDid && '' !== agent.orgDid
+        );
+
         // If there are org DIDs that do not exist in org_dids table
         if (orgDids.length !== existingDids.length) {
-            const newOrgAgents = orgAgents.filter(
+            const newOrgAgents = filteredOrgAgents.filter(
                 (agent) => !existingDids.some((did) => did.did === agent.orgDid)
             );
 


### PR DESCRIPTION
## What:
- Fixes schema search due to default pageNumber
## Why:
- Previously search text only allowed searching schema from 1st paginated page (by default). This caused issue for searching schema across all available schemas