### PR TITLE
fix: provision for parentThreadId in proofRequest

### DIFF
--- a/apps/api-gateway/src/verification/dto/webhook-proof.dto.ts
+++ b/apps/api-gateway/src/verification/dto/webhook-proof.dto.ts
@@ -43,6 +43,10 @@ export class WebhookPresentationProofDto {
 
     @ApiPropertyOptional()
     @IsOptional()
+    parentThreadId?: string;
+
+    @ApiPropertyOptional()
+    @IsOptional()
     presentationId: string;
 
     @ApiPropertyOptional()

--- a/apps/verification/src/interfaces/verification.interface.ts
+++ b/apps/verification/src/interfaces/verification.interface.ts
@@ -135,6 +135,7 @@ export interface IPresentationExchangeProofFormats {
 export interface ISendPresentationExchangeProofRequestPayload {
     protocolVersion: string;
     comment: string;
+    parentThreadId?: string;
     proofFormats: IPresentationExchangeProofFormats;
     autoAcceptProof: string;
     label?: string;
@@ -206,6 +207,7 @@ export interface IWebhookProofPresentation {
     connectionId: string;
     presentationId: string;
     threadId: string;
+    parentThreadId?: string;
     autoAcceptProof: string;
     updatedAt: string;
     isVerified: boolean;

--- a/apps/verification/src/verification.service.ts
+++ b/apps/verification/src/verification.service.ts
@@ -433,6 +433,7 @@ export class VerificationService {
           url,
           proofRequestPayload: {
             goalCode: outOfBandRequestProof.goalCode,
+            parentThreadId: outOfBandRequestProof.parentThreadId,
             protocolVersion:outOfBandRequestProof.protocolVersion || 'v2',
             comment:outOfBandRequestProof.comment,
             label,


### PR DESCRIPTION
what?
Added provision to pass parentThreadId in proofRequest creation payload and use it in further process

why?
As a part of NDI requirement we needed this to pass from proof request creation payload. We did not had this provision in CREDEBL, hence adding this PR.