### PR TITLE
refactor: get all cred defs by orgId functionality (#1084)

### DIFF
--- a/libs/common/src/interfaces/schema.interface.ts
+++ b/libs/common/src/interfaces/schema.interface.ts
@@ -62,6 +62,10 @@ export interface ISchemasWithPagination extends IPaginationDetails{
     orgId: string;
     ledgerId: string;
     type: string;
+    isSchemaArchived: boolean,
+    organisation: {
+      name: string
+    }
   }
 
   export interface IPlatformSchemas {


### PR DESCRIPTION
### What?
- Added a check in the "Get All Credential Definitions by OrgId" API to fetch only those credential definitions whose aligned schemas are not archived.