### PR TITLE
fix: added api param validations

### DIFF
--- a/apps/api-gateway/src/agent-service/agent-service.controller.ts
+++ b/apps/api-gateway/src/agent-service/agent-service.controller.ts
@@ -72,7 +72,10 @@ export class AgentController {
     description: 'Get the agent health details for the organization'
   })
   @UseGuards(AuthGuard('jwt'))
-  async getAgentHealth(@Param('orgId') orgId: string, @User() reqUser: user, @Res() res: Response): Promise<Response> {
+  async getAgentHealth(
+    @Param('orgId', TrimStringParamPipe, new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, 
+    @User() reqUser: user, 
+    @Res() res: Response): Promise<Response> {
     const agentData = await this.agentService.getAgentHealth(reqUser, orgId);
 
     const finalResponse: IResponse = {

--- a/apps/api-gateway/src/connection/connection.controller.ts
+++ b/apps/api-gateway/src/connection/connection.controller.ts
@@ -23,6 +23,7 @@ import { ClientProxy} from '@nestjs/microservices';
 import { BasicMessageDto, QuestionAnswerWebhookDto, QuestionDto} from './dtos/question-answer.dto';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { user } from '@prisma/client';
+import { TrimStringParamPipe } from '@credebl/common/cast.helper';
 @UseFilters(CustomExceptionFilter)
 @Controller()
 @ApiTags('connections')
@@ -52,8 +53,8 @@ export class ConnectionController {
     @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
     async getConnectionsById(
         @User() user: IUserRequest,
-        @Param('connectionId') connectionId: string,
-        @Param('orgId') orgId: string,
+        @Param('orgId', TrimStringParamPipe, new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string,
+        @Param('connectionId', TrimStringParamPipe, new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.connection.error.invalidConnectionId); }})) connectionId: string,
         @Res() res: Response
     ): Promise<Response> {
         const connectionsDetails = await this.connectionService.getConnectionsById(user, connectionId, orgId);
@@ -149,16 +150,26 @@ export class ConnectionController {
      * @returns Question-answer record for a specific organization
      */
     @Get('orgs/:orgId/question-answer/question')
-    @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
-    @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER, OrgRoles.HOLDER, OrgRoles.SUPER_ADMIN, OrgRoles.PLATFORM_ADMIN)
     @ApiOperation({
-        summary: `Get question-answer record`,
-        description: `Retrieve the question-answer record for a specific organization.`
+      summary: `Get question-answer record`,
+      description: `Retrieve the question-answer record for a specific organization.`
     })
+    @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER, OrgRoles.HOLDER, OrgRoles.SUPER_ADMIN, OrgRoles.PLATFORM_ADMIN)
+    @ApiBearerAuth()
+    @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
     @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
     async getQuestionAnswersRecord(
-        @Param('orgId') orgId: string,
-        @Res() res: Response
+      @Param(
+        'orgId',
+        TrimStringParamPipe,
+        new ParseUUIDPipe({
+          exceptionFactory: (): Error => {
+            throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId);
+          }
+        })
+      )  
+      orgId: string,      
+      @Res() res: Response
     ): Promise<Response> {
         const record = await this.connectionService.getQuestionAnswersRecord(orgId);
         const finalResponse: IResponse = {
@@ -416,13 +427,14 @@ export class ConnectionController {
  * @returns The details of the sent basic message
  */
   @Post('/orgs/:orgId/basic-message/:connectionId')
-    @ApiOperation({ summary: 'Send basic message', description: 'Send a basic message to a specific connection for a specific organization.' })
-    @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
+  @ApiOperation({ summary: 'Send basic message', description: 'Send a basic message to a specific connection for a specific organization.' })
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
     @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER, OrgRoles.MEMBER, OrgRoles.HOLDER, OrgRoles.SUPER_ADMIN, OrgRoles.PLATFORM_ADMIN)
     @ApiResponse({ status: HttpStatus.CREATED, description: 'Created', type: ApiResponseDto })
     async sendBasicMessage(
-        @Param('orgId') orgId: string,
-        @Param('connectionId') connectionId: string,
+      @Param('orgId', TrimStringParamPipe, new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, 
+      @Param('connectionId', TrimStringParamPipe, new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.connection.error.invalidConnectionId); }})) connectionId: string,
         @Body() basicMessageDto: BasicMessageDto,
         @User() reqUser: IUserRequestInterface,
         @Res() res: Response

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -110,7 +110,10 @@ export class OrganizationController {
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
-  async getOrgRoles(@Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, @User() user: user, @Res() res: Response): Promise<Response> {
+  async getOrgRoles(
+    @Param('orgId', TrimStringParamPipe, new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, 
+    @User() user: user, 
+    @Res() res: Response): Promise<Response> {
 
     const orgRoles = await this.organizationService.getOrgRoles(orgId.trim(), user);
 

--- a/apps/api-gateway/src/user/user.controller.ts
+++ b/apps/api-gateway/src/user/user.controller.ts
@@ -50,6 +50,7 @@ import { OrgRoles } from 'libs/org-roles/enums';
 import { AwsService } from '@credebl/aws/aws.service';
 import { PaginationDto } from '@credebl/common/dtos/pagination.dto';
 import { UserAccessGuard } from '../authz/guards/user-access-guard';
+import { TrimStringParamPipe } from '@credebl/common/cast.helper';
 
 @UseFilters(CustomExceptionFilter)
 @Controller('users')
@@ -306,7 +307,7 @@ export class UserController {
   @ApiBearerAuth()
   async acceptRejectInvitaion(
       @Body() acceptRejectInvitation: AcceptRejectInvitationDto,
-      @Param('invitationId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(`Invalid format for InvitationId`); }})) invitationId: string,
+      @Param('invitationId', TrimStringParamPipe, new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(`Invalid format for InvitationId`); }})) invitationId: string,
     @User() reqUser: user,
     @Res() res: Response
   ): Promise<Response> {

--- a/apps/api-gateway/src/webhook/dtos/get-webhoook-dto.ts
+++ b/apps/api-gateway/src/webhook/dtos/get-webhoook-dto.ts
@@ -1,5 +1,5 @@
 import { ApiExtraModels, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { trim } from '@credebl/common/cast.helper';
 
@@ -15,6 +15,7 @@ export class GetWebhookDto {
     @ApiPropertyOptional({example: '3a041d6e-d24c-4ed9-b011-1cfc371a8b8e'})
     @IsOptional()
     @Transform(({ value }) => trim(value))
+    @IsUUID('4', { message: 'Please provide valid tenantId' })
     @IsString({ message: 'Tenant id must be in string format.' })
     tenantId?: string;
 }

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -282,6 +282,7 @@ export const ResponseMessages = {
       basicMessage: 'Basic message sent successfully'
     },
     error: {
+      invalidConnectionId: 'Invalid format for connectionId',
       exists: 'Connection is already exist',
       connectionNotFound: 'Connection not found',
       agentEndPointNotFound: 'agentEndPoint Not Found',


### PR DESCRIPTION
### What?
- Resolved following bugs:
1). https://credebl.atlassian.net/browse/CREDEBL-513 (Bug(API): Incorrect response received when providing invalid `tenant ID` for webhook URL details)
2). https://credebl.atlassian.net/browse/CREDEBL-547 (Bug(API): Received an incorrect response when providing space before valid `invitationId`during organization invitation Acceptance/Rejection)
3). https://credebl.atlassian.net/browse/CREDEBL-548 (Bug(API): Incorrect response received when a space is added before a valid orgId while fetching org-role details)
4). https://credebl.atlassian.net/browse/CREDEBL-555 (Bug(API): Received an incorrect response when providing a space before a valid connectionId while fetching connections by connection ID)