### PR TITLE
fix: local setup issues

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -121,7 +121,7 @@ AFJ_AGENT_SPIN_UP=/agent-provisioning/AFJ/scripts/docker_start_agent.sh
 AFJ_AGENT_ENDPOINT_PATH=/agent-provisioning/AFJ/endpoints/
 # Uncomment bellow three lines and comment the above to start services locally without using docker, using pnpm
 # AFJ_AGENT_TOKEN_PATH=/apps/agent-provisioning/AFJ/token/
-# AFJ_AGENT_SPIN_UP=/apps/agent-provisioning/AFJ/scripts/docker_start_agent.sh
+# AFJ_AGENT_SPIN_UP=/apps/agent-provisioning/AFJ/scripts/start_agent.sh
 # AFJ_AGENT_ENDPOINT_PATH=/apps/agent-provisioning/AFJ/endpoints/
  
 AGENT_PROTOCOL=http

--- a/apps/agent-provisioning/AFJ/scripts/start_agent.sh
+++ b/apps/agent-provisioning/AFJ/scripts/start_agent.sh
@@ -209,7 +209,7 @@ if [ $? -eq 0 ]; then
 
   docker rm -f "${PROJECT_NAME}" || true
 
-  docker-compose -f $FILE_NAME --project-name "${PROJECT_NAME}" up -d
+  docker compose -f $FILE_NAME --project-name "${PROJECT_NAME}" up -d
   if [ $? -eq 0 ]; then
 
     n=0


### PR DESCRIPTION
## What:
- Some of the latest docker version requires `docker compose` instead of previously used `docker-compose`
- Change in scripts for local setup in the `.demo.env`. This configurations are only enabled for local setup using `pnpm` and not for `docker`ized builds