### PR TITLE
fix: Update GET proof record endpoint to return 404 for non-existing records

### DIFF
--- a/apps/verification/src/verification.service.ts
+++ b/apps/verification/src/verification.service.ts
@@ -187,17 +187,13 @@ export class VerificationService {
       return getProofPresentationById?.response;
     } catch (error) {
       this.logger.error(`[getProofPresentationById] - error in get proof presentation by proofId : ${JSON.stringify(error)}`);
-      const errorStack = error?.response?.error?.reason;
+      const errorMessage = error?.response?.error?.reason || error?.message;
 
-      if (errorStack) {
-        throw new RpcException({
-          message: ResponseMessages.verification.error.proofNotFound,
-          statusCode: error?.response?.status,
-          error: errorStack
-        });
-      } else {
-        throw new RpcException(error.response ? error.response : error);
+      if (errorMessage?.includes('not found')) {
+        throw new NotFoundException(errorMessage);
       }
+
+      throw new RpcException(error.response ? error.response : error);
     }
   }
 


### PR DESCRIPTION
Issue Fixed:
I addressed the error handling in the proof record retrieval endpoint where it was returning a 500 status code for non-existing records. The issue was in the verification service's error handling logic.

Changes Made:
1. Modified error handling in verification.service.ts for the getProofPresentationById method
2. Updated the error detection to properly identify "record not found" cases
3. Implemented proper 404 response using NestJS's NotFoundException
4. Maintained the original error message for clarity

Before:
- API returned 500 status code with a generic error
- Error structure was inconsistent with API standards
- Generic "Something went wrong!" message wasn't helpful

After:
- API now returns 404 status code for non-existing records
- Clear error message indicates the specific proofId that wasn't found
- Consistent error structure throughout the API
- Better error handling helps client applications handle missing records appropriately

This change improves the API's error handling consistency and provides better feedback for client applications trying to access non-existing proof records.