### PR TITLE
fix: issues related nested attributes in issuance process

### DIFF
--- a/apps/api-gateway/src/dtos/create-schema.dto.ts
+++ b/apps/api-gateway/src/dtos/create-schema.dto.ts
@@ -1,3 +1,4 @@
+import { ApiExtraModels, ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
 import {
   ArrayMinSize,
   IsArray,
@@ -13,11 +14,9 @@ import {
   ValidateIf,
   ValidateNested
 } from 'class-validator';
-
-import { ApiExtraModels, ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
-import { plainToClass, Transform, Type } from 'class-transformer';
-import { IsNotSQLInjection, trim } from '@credebl/common/cast.helper';
 import { IndySchemaDataType, JSONSchemaType, SchemaTypeEnum, W3CSchemaDataType } from '@credebl/enum/enum';
+import { IsNotSQLInjection, ValidateNestedStructureFields, trim } from '@credebl/common/cast.helper';
+import { Transform, Type, plainToClass } from 'class-transformer';
 
 export class W3CAttributeValue {
   @ApiProperty()
@@ -40,6 +39,7 @@ export class W3CAttributeValue {
   @IsEnum(W3CSchemaDataType, {
     message: `Schema data type must be one of [${Object.values(W3CSchemaDataType).join(', ')}]`
   })
+  @ValidateNestedStructureFields()
   schemaDataType: W3CSchemaDataType;
 
   @ApiProperty()

--- a/apps/api-gateway/src/issuance/dtos/issuance.dto.ts
+++ b/apps/api-gateway/src/issuance/dtos/issuance.dto.ts
@@ -13,11 +13,12 @@ import {
   IsObject,
   IsOptional,
   IsString,
-  IsUrl,
   IsUUID,
+  IsUrl,
   MaxLength,
   ValidateNested
 } from 'class-validator';
+import { AutoAccept, SchemaType, SortValue } from '@credebl/enum/enum';
 import { IsCredentialJsonLdContext, SingleOrArray } from '../utils/helper';
 import {
   IssueCredentialType,
@@ -27,7 +28,6 @@ import {
 } from '../interfaces';
 import { Transform, Type } from 'class-transformer';
 
-import { AutoAccept, SchemaType, SortValue } from '@credebl/enum/enum';
 import { SortFields } from 'apps/connection/src/enum/connection.enum';
 import { trim } from '@credebl/common/cast.helper';
 
@@ -486,6 +486,8 @@ export class OOBCredentialDtoWithEmail {
   isReuseConnection?: boolean;
 
   imageUrl?: string;
+
+  isValidateSchema?: boolean;
 
   orgId: string;
 }

--- a/apps/api-gateway/src/issuance/dtos/issuance.dto.ts
+++ b/apps/api-gateway/src/issuance/dtos/issuance.dto.ts
@@ -656,8 +656,7 @@ export class FileQuery {
 }
 
 export class RequestIdQuery {
-  @ApiPropertyOptional({ required: false })
-  @IsOptional()
+  @ApiProperty()
   @IsString({ message: 'requestId should be string' })
   @IsNotEmpty({ message: 'requestId Id is required' })
   @Transform(({ value }) => trim(value))

--- a/apps/api-gateway/src/issuance/issuance.controller.ts
+++ b/apps/api-gateway/src/issuance/issuance.controller.ts
@@ -291,7 +291,7 @@ export class IssuanceController {
         .send(templateData.fileContent);
     } catch (error) {
       return res
-        .status(error.statusCode)
+        .status(error.statusCode || HttpStatus.INTERNAL_SERVER_ERROR)
         .header('Content-Type', 'application/json')
         .header('Content-Disposition', '')
         .send(error);

--- a/apps/api-gateway/src/issuance/issuance.service.ts
+++ b/apps/api-gateway/src/issuance/issuance.service.ts
@@ -49,6 +49,7 @@ export class IssuanceService extends BaseService {
       protocolVersion: issueCredentialDto.protocolVersion,
       autoAcceptCredential: issueCredentialDto.autoAcceptCredential,
       credentialType: issueCredentialDto.credentialType,
+      isValidateSchema: issueCredentialDto.isValidateSchema,
       user
     };
 
@@ -172,8 +173,8 @@ export class IssuanceService extends BaseService {
       .response;
   }
 
-  async uploadCSVTemplate(importFileDetails: UploadedFileDetails): Promise<{ response: object }> {
-    const payload = { importFileDetails };
+  async uploadCSVTemplate(importFileDetails: UploadedFileDetails, orgId: string): Promise<{ response: object }> {
+    const payload = { importFileDetails, orgId };
     return this.natsClient.sendNats(this.issuanceProxy, 'upload-csv-template', payload);
   }
 

--- a/apps/issuance/interfaces/issuance.interfaces.ts
+++ b/apps/issuance/interfaces/issuance.interfaces.ts
@@ -1,10 +1,11 @@
 // eslint-disable-next-line camelcase
 import { AutoAccept, SchemaType } from '@credebl/enum/enum';
-import { IUserRequest } from '@credebl/user-request/user-request.interface';
 import { Prisma, organisation } from '@prisma/client';
+
+import { IPrettyVc } from '@credebl/common/interfaces/issuance.interface';
+import { IUserRequest } from '@credebl/user-request/user-request.interface';
 import { IUserRequestInterface } from 'apps/agent-service/src/interface/agent-service.interface';
 import { IssueCredentialType } from 'apps/api-gateway/src/issuance/interfaces';
-import { IPrettyVc } from '@credebl/common/interfaces/issuance.interface';
 
 export interface IAttributes {
   attributeName: string;
@@ -32,6 +33,7 @@ export interface IIssuance {
   willConfirm?: boolean;
   label?: string;
   credentialType: string;
+  isValidateSchema?: string;
 }
 
 interface IIndy {
@@ -178,6 +180,7 @@ export interface OutOfBandCredentialOfferPayload {
   imageUrl?: string;
   autoAcceptCredential?: string;
   credentialType?: IssueCredentialType;
+  isValidateSchema?: boolean;
 }
 
 export interface OutOfBandCredentialOffer {

--- a/apps/issuance/src/issuance.controller.ts
+++ b/apps/issuance/src/issuance.controller.ts
@@ -1,17 +1,32 @@
+import {
+  IClientDetails,
+  IIssuance,
+  IIssueCredentials,
+  IIssueCredentialsDefinitions,
+  ImportFileDetails,
+  IssueCredentialWebhookPayload,
+  OutOfBandCredentialOffer,
+  PreviewRequest,
+  TemplateDetailsInterface
+} from '../interfaces/issuance.interfaces';
+import {
+  ICredentialOfferResponse,
+  IDeletedIssuanceRecords,
+  IIssuedCredential
+} from '@credebl/common/interfaces/issuance.interface';
+
 import { Controller } from '@nestjs/common';
-import { MessagePattern } from '@nestjs/microservices';
-import { IClientDetails, IIssuance, IIssueCredentials, IIssueCredentialsDefinitions, ImportFileDetails, IssueCredentialWebhookPayload, OutOfBandCredentialOffer, PreviewRequest, TemplateDetailsInterface } from '../interfaces/issuance.interfaces';
 import { IssuanceService } from './issuance.service';
-import { ICredentialOfferResponse, IDeletedIssuanceRecords, IIssuedCredential } from '@credebl/common/interfaces/issuance.interface';
+import { MessagePattern } from '@nestjs/microservices';
 import { OOBIssueCredentialDto } from 'apps/api-gateway/src/issuance/dtos/issuance.dto';
 import { user } from '@prisma/client';
 
 @Controller()
 export class IssuanceController {
-  constructor(private readonly issuanceService: IssuanceService) { }
+  constructor(private readonly issuanceService: IssuanceService) {}
 
   @MessagePattern({ cmd: 'get-issuance-records' })
-  async getIssuanceRecordsByOrgId(payload: { orgId: string, userId: string }): Promise<number> {
+  async getIssuanceRecordsByOrgId(payload: { orgId: string; userId: string }): Promise<number> {
     const { orgId } = payload;
     return this.issuanceService.getIssuanceRecords(orgId);
   }
@@ -22,7 +37,7 @@ export class IssuanceController {
   }
 
   @MessagePattern({ cmd: 'send-credential-create-offer-oob' })
-  async sendCredentialOutOfBand(payload: OOBIssueCredentialDto): Promise<{response: object;}> { 
+  async sendCredentialOutOfBand(payload: OOBIssueCredentialDto): Promise<{ response: object }> {
     return this.issuanceService.sendCredentialOutOfBand(payload);
   }
 
@@ -38,7 +53,6 @@ export class IssuanceController {
     return this.issuanceService.getIssueCredentialsbyCredentialRecordId(user, credentialRecordId, orgId);
   }
 
-
   @MessagePattern({ cmd: 'webhook-get-issue-credential' })
   async getIssueCredentialWebhook(payload: IssueCredentialWebhookPayload): Promise<object> {
     return this.issuanceService.getIssueCredentialWebhook(payload);
@@ -52,63 +66,71 @@ export class IssuanceController {
 
   @MessagePattern({ cmd: 'download-csv-template-for-bulk-operation' })
   async downloadBulkIssuanceCSVTemplate(payload: {
-    orgId: string, templateDetails: TemplateDetailsInterface
+    orgId: string;
+    templateDetails: TemplateDetailsInterface;
   }): Promise<object> {
-    const {templateDetails} = payload;
-    return this.issuanceService.downloadBulkIssuanceCSVTemplate(templateDetails);
+    const { orgId, templateDetails } = payload;
+    return this.issuanceService.downloadBulkIssuanceCSVTemplate(orgId, templateDetails);
   }
 
   @MessagePattern({ cmd: 'upload-csv-template' })
-  async uploadCSVTemplate(payload: {
-    importFileDetails: ImportFileDetails
-  }): Promise<string> {
-    return this.issuanceService.uploadCSVTemplate(payload.importFileDetails);
+  async uploadCSVTemplate(payload: { importFileDetails: ImportFileDetails; orgId: string }): Promise<string> {
+    return this.issuanceService.uploadCSVTemplate(payload.importFileDetails, payload.orgId);
   }
 
   @MessagePattern({ cmd: 'preview-csv-details' })
-  async previewCSVDetails(payload: { requestId: string, previewFileDetails: PreviewRequest }): Promise<object> {
-    return this.issuanceService.previewFileDataForIssuance(
-      payload.requestId,
-      payload.previewFileDetails
-    );
+  async previewCSVDetails(payload: { requestId: string; previewFileDetails: PreviewRequest }): Promise<object> {
+    return this.issuanceService.previewFileDataForIssuance(payload.requestId, payload.previewFileDetails);
   }
 
   @MessagePattern({ cmd: 'issued-file-details' })
-  async issuedFiles(payload: { orgId: string, fileParameter: PreviewRequest }): Promise<object> {
-    return this.issuanceService.issuedFileDetails(
-      payload.orgId,
-      payload.fileParameter
-    );
+  async issuedFiles(payload: { orgId: string; fileParameter: PreviewRequest }): Promise<object> {
+    return this.issuanceService.issuedFileDetails(payload.orgId, payload.fileParameter);
   }
   @MessagePattern({ cmd: 'issued-file-data' })
-  async getFileDetailsByFileId(payload: { fileId: string, fileParameter: PreviewRequest }): Promise<object> {
-    return this.issuanceService.getFileDetailsByFileId(
-      payload.fileId,
-      payload.fileParameter
-    );
+  async getFileDetailsByFileId(payload: { fileId: string; fileParameter: PreviewRequest }): Promise<object> {
+    return this.issuanceService.getFileDetailsByFileId(payload.fileId, payload.fileParameter);
   }
 
-
   @MessagePattern({ cmd: 'issue-bulk-credentials' })
-  async issueBulkCredentials(payload: { requestId: string, orgId: string, clientDetails: IClientDetails, reqPayload: ImportFileDetails, isValidateSchema: boolean }): Promise<string> {
-    return this.issuanceService.issueBulkCredential(payload.requestId, payload.orgId, payload.clientDetails, payload.reqPayload, payload.isValidateSchema);
+  async issueBulkCredentials(payload: {
+    requestId: string;
+    orgId: string;
+    clientDetails: IClientDetails;
+    reqPayload: ImportFileDetails;
+    isValidateSchema: boolean;
+  }): Promise<string> {
+    return this.issuanceService.issueBulkCredential(
+      payload.requestId,
+      payload.orgId,
+      payload.clientDetails,
+      payload.reqPayload,
+      payload.isValidateSchema
+    );
   }
 
   @MessagePattern({ cmd: 'retry-bulk-credentials' })
-  async retryeBulkCredentials(payload: { fileId: string, orgId: string, clientDetails: IClientDetails, isValidateSchema?: boolean }): Promise<string> {
-    return this.issuanceService.retryBulkCredential(payload.fileId, payload.orgId, payload.clientDetails, payload.isValidateSchema);
+  async retryeBulkCredentials(payload: {
+    fileId: string;
+    orgId: string;
+    clientDetails: IClientDetails;
+    isValidateSchema?: boolean;
+  }): Promise<string> {
+    return this.issuanceService.retryBulkCredential(
+      payload.fileId,
+      payload.orgId,
+      payload.clientDetails,
+      payload.isValidateSchema
+    );
   }
 
   @MessagePattern({ cmd: 'delete-issuance-records' })
-  async deleteIssuanceRecords(payload: {orgId: string, userDetails: user}): Promise<IDeletedIssuanceRecords> {  
+  async deleteIssuanceRecords(payload: { orgId: string; userDetails: user }): Promise<IDeletedIssuanceRecords> {
     const { orgId, userDetails } = payload;
     return this.issuanceService.deleteIssuanceRecords(orgId, userDetails);
   }
   @MessagePattern({ cmd: 'issued-file-data-and-file-details' })
-  async getFileDetailsAndFileDataByFileId(payload: { fileId: string, orgId: string }): Promise<object> {
-    return this.issuanceService.getFileDetailsAndFileDataByFileId(
-      payload.fileId,
-      payload.orgId
-    );
+  async getFileDetailsAndFileDataByFileId(payload: { fileId: string; orgId: string }): Promise<object> {
+    return this.issuanceService.getFileDetailsAndFileDataByFileId(payload.fileId, payload.orgId);
   }
 }

--- a/apps/issuance/src/issuance.repository.ts
+++ b/apps/issuance/src/issuance.repository.ts
@@ -1,6 +1,15 @@
 /* eslint-disable camelcase */
 import { ConflictException, Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
-import { PrismaService } from '@credebl/prisma-service';
+import {
+  FileUpload,
+  FileUploadData,
+  IDeletedFileUploadRecords,
+  IssueCredentialWebhookPayload,
+  OrgAgent,
+  PreviewRequest,
+  SchemaDetails
+} from '../interfaces/issuance.interfaces';
+import { PrismaTables, SortValue } from '@credebl/enum/enum';
 // eslint-disable-next-line camelcase
 import {
   agent_invitations,
@@ -12,21 +21,13 @@ import {
   platform_config,
   schema
 } from '@prisma/client';
-import { ResponseMessages } from '@credebl/common/response-messages';
-import {
-  FileUpload,
-  FileUploadData,
-  IDeletedFileUploadRecords,
-  IssueCredentialWebhookPayload,
-  OrgAgent,
-  PreviewRequest,
-  SchemaDetails
-} from '../interfaces/issuance.interfaces';
+
 import { FileUploadStatus } from 'apps/api-gateway/src/enum';
-import { IUserRequest } from '@credebl/user-request/user-request.interface';
-import { IIssuedCredentialSearchParams } from 'apps/api-gateway/src/issuance/interfaces';
-import { PrismaTables, SortValue } from '@credebl/enum/enum';
 import { IDeletedIssuanceRecords } from '@credebl/common/interfaces/issuance.interface';
+import { IIssuedCredentialSearchParams } from 'apps/api-gateway/src/issuance/interfaces';
+import { IUserRequest } from '@credebl/user-request/user-request.interface';
+import { PrismaService } from '@credebl/prisma-service';
+import { ResponseMessages } from '@credebl/common/response-messages';
 @Injectable()
 export class IssuanceRepository {
   constructor(
@@ -121,12 +122,19 @@ export class IssuanceRepository {
       orgId: string;
     }[];
   }> {
-    try {   
+    try {
       const issuedCredentialsList = await this.prisma.credentials.findMany({
         where: {
           orgId,
           ...(schemaIds?.length ? { schemaId: { in: schemaIds } } : {}),
-          ...(!schemaIds?.length && issuedCredentialsSearchCriteria.search ? { OR: [{ connectionId: { contains: issuedCredentialsSearchCriteria.search, mode: 'insensitive' } }, { schemaId: { contains: issuedCredentialsSearchCriteria.search, mode: 'insensitive' } }] } : {})
+          ...(!schemaIds?.length && issuedCredentialsSearchCriteria.search
+            ? {
+                OR: [
+                  { connectionId: { contains: issuedCredentialsSearchCriteria.search, mode: 'insensitive' } },
+                  { schemaId: { contains: issuedCredentialsSearchCriteria.search, mode: 'insensitive' } }
+                ]
+              }
+            : {})
         },
         select: {
           credentialExchangeId: true,
@@ -148,7 +156,14 @@ export class IssuanceRepository {
         where: {
           orgId,
           ...(schemaIds?.length ? { schemaId: { in: schemaIds } } : {}),
-          ...(!schemaIds?.length && issuedCredentialsSearchCriteria.search ? { OR: [{ connectionId: { contains: issuedCredentialsSearchCriteria.search, mode: 'insensitive' } }, { schemaId: { contains: issuedCredentialsSearchCriteria.search, mode: 'insensitive' } }] } : {})
+          ...(!schemaIds?.length && issuedCredentialsSearchCriteria.search
+            ? {
+                OR: [
+                  { connectionId: { contains: issuedCredentialsSearchCriteria.search, mode: 'insensitive' } },
+                  { schemaId: { contains: issuedCredentialsSearchCriteria.search, mode: 'insensitive' } }
+                ]
+              }
+            : {})
         }
       });
 
@@ -179,13 +194,16 @@ export class IssuanceRepository {
 
       let schemaId = '';
 
-        if (
-          (issueCredentialDto?.metadata?.['_anoncreds/credential']?.schemaId ||
-           issueCredentialDto?.['credentialData']?.offer?.jsonld?.credential?.['@context'][1]) ||
-          (issueCredentialDto?.state &&
-           issueCredentialDto?.['credentialData']?.proposal?.jsonld?.credential?.['@context'][1])
-        ) {
-        schemaId = issueCredentialDto?.metadata?.['_anoncreds/credential']?.schemaId || issueCredentialDto?.['credentialData']?.offer?.jsonld?.credential?.['@context'][1] || issueCredentialDto?.['credentialData']?.proposal?.jsonld?.credential?.['@context'][1];
+      if (
+        issueCredentialDto?.metadata?.['_anoncreds/credential']?.schemaId ||
+        issueCredentialDto?.['credentialData']?.offer?.jsonld?.credential?.['@context'][1] ||
+        (issueCredentialDto?.state &&
+          issueCredentialDto?.['credentialData']?.proposal?.jsonld?.credential?.['@context'][1])
+      ) {
+        schemaId =
+          issueCredentialDto?.metadata?.['_anoncreds/credential']?.schemaId ||
+          issueCredentialDto?.['credentialData']?.offer?.jsonld?.credential?.['@context'][1] ||
+          issueCredentialDto?.['credentialData']?.proposal?.jsonld?.credential?.['@context'][1];
       }
 
       let credDefId = '';
@@ -284,7 +302,6 @@ export class IssuanceRepository {
 
       const schemaDetails = await this.getSchemaDetailsBySchemaIdentifier(credentialDefinitionDetails.schemaLedgerId);
 
-      
       if (!schemaDetails) {
         throw new NotFoundException(`Schema not found for credential definition ID: ${credentialDefinitionId}`);
       }
@@ -305,7 +322,7 @@ export class IssuanceRepository {
   }
 
   async getSchemaDetailsBySchemaIdentifier(schemaIdentifier: string): Promise<schema> {
-    const schemaDetails = await this.prisma.schema.findFirstOrThrow({
+    const schemaDetails = await this.prisma.schema.findFirst({
       where: {
         schemaLedgerId: schemaIdentifier
       }
@@ -627,7 +644,6 @@ export class IssuanceRepository {
   async deleteFileUploadData(fileUploadIds: string[], orgId: string): Promise<IDeletedFileUploadRecords> {
     try {
       return await this.prisma.$transaction(async (prisma) => {
-
         const deleteFileDetails = await prisma.file_data.deleteMany({
           where: {
             fileUploadId: {
@@ -643,7 +659,6 @@ export class IssuanceRepository {
         });
 
         return { deleteFileDetails, deleteFileUploadDetails };
-    
       });
     } catch (error) {
       this.logger.error(`[Error in deleting file data] - error: ${JSON.stringify(error)}`);
@@ -676,7 +691,6 @@ export class IssuanceRepository {
       }
 
       return await this.prisma.$transaction(async (prisma) => {
-        
         const recordsToDelete = await this.prisma.credentials.findMany({
           where: { orgId },
           select: {
@@ -693,26 +707,23 @@ export class IssuanceRepository {
           where: { orgId }
         });
 
-        return { deleteResult, recordsToDelete};
+        return { deleteResult, recordsToDelete };
       });
     } catch (error) {
       this.logger.error(`Error in deleting issuance records: ${error.message}`);
       throw error;
     }
   }
-  async getFileDetailsAndFileDataByFileId(
-    fileId: string,
-    orgId:string
-  ): Promise<object> {
+  async getFileDetailsAndFileDataByFileId(fileId: string, orgId: string): Promise<object> {
     try {
       const fileDetails = await this.prisma.file_upload.findUnique({
-       where: {
-        id:fileId, 
-        orgId
-       },
-       include : {
-        file_data:true
-       }
+        where: {
+          id: fileId,
+          orgId
+        },
+        include: {
+          file_data: true
+        }
       });
       return fileDetails;
     } catch (error) {

--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -142,7 +142,7 @@ export class IssuanceService {
 
   async sendCredentialCreateOffer(payload: IIssuance): Promise<ICredentialOfferResponse> {
     try {
-      const { orgId, credentialDefinitionId, comment, credentialData } = payload || {};
+      const { orgId, credentialDefinitionId, comment, credentialData, isValidateSchema } = payload || {};
 
       if (payload.credentialType === IssueCredentialType.INDY) {
         const schemaResponse: SchemaDetails =
@@ -226,7 +226,10 @@ export class IssuanceService {
           const schemaServerUrl = issueData?.credentialFormats?.jsonld?.credential?.['@context']?.[1];
 
           const schemaUrlAttributes = await this.getW3CSchemaAttributes(schemaServerUrl);
-          validateW3CSchemaAttributes(filteredIssuanceAttributes, schemaUrlAttributes);
+
+          if (isValidateSchema) {
+            validateW3CSchemaAttributes(filteredIssuanceAttributes, schemaUrlAttributes);
+          }
         }
 
         await this.delay(500);
@@ -714,8 +717,7 @@ export class IssuanceService {
     outOfBandCredential: OutOfBandCredentialOfferPayload,
     platformName?: string,
     organizationLogoUrl?: string,
-    prettyVc?: IPrettyVc,
-    isValidateSchema?: boolean
+    prettyVc?: IPrettyVc
   ): Promise<boolean> {
     try {
       const {
@@ -727,7 +729,8 @@ export class IssuanceService {
         attributes,
         emailId,
         credentialType,
-        isReuseConnection
+        isReuseConnection,
+        isValidateSchema
       } = outOfBandCredential;
 
       if (IssueCredentialType.JSONLD === credentialType) {
@@ -1151,10 +1154,12 @@ export class IssuanceService {
     }
   }
 
-  async downloadBulkIssuanceCSVTemplate(templateDetails: TemplateDetailsInterface): Promise<object> {
+  async downloadBulkIssuanceCSVTemplate(orgId: string, templateDetails: TemplateDetailsInterface): Promise<object> {
     try {
       let schemaResponse: SchemaDetails;
       let fileName: string;
+
+      const orgDetails = await this.issuanceRepository.getAgentEndPoint(orgId);
 
       const { schemaType, templateId } = templateDetails;
 
@@ -1163,25 +1168,32 @@ export class IssuanceService {
       }
       const timestamp = Math.floor(Date.now() / 1000);
 
-      const schemaData = await this.issuanceRepository.getSchemaDetailsBySchemaIdentifier(templateId);
-
-      if (schemaData?.type !== schemaType) {
-        throw new BadRequestException(ResponseMessages.bulkIssuance.error.mismatchedSchemaType);
-      }
-
       if (schemaType === SchemaType.INDY) {
         schemaResponse = await this.issuanceRepository.getCredentialDefinitionDetails(templateId);
+
         if (!schemaResponse) {
           throw new NotFoundException(ResponseMessages.bulkIssuance.error.invalidIdentifier);
         }
+
+        const schemaDetails = await this.issuanceRepository.getSchemaDetails(schemaResponse.schemaLedgerId);
+
+        if (orgDetails?.ledgerId !== schemaDetails?.ledgerId) {
+          throw new BadRequestException(ResponseMessages.issuance.error.ledgerMismatched);
+        }
+
         fileName = `${schemaResponse.tag}-${timestamp}.csv`;
       } else if (schemaType === SchemaType.W3C_Schema) {
         const schemaDetails = await this.issuanceRepository.getSchemaDetailsBySchemaIdentifier(templateId);
-        const { attributes, schemaLedgerId, name } = schemaDetails;
-        schemaResponse = { attributes, schemaLedgerId, name };
-        if (!schemaResponse) {
+
+        if (orgDetails?.ledgerId !== schemaDetails?.ledgerId) {
+          throw new BadRequestException(ResponseMessages.issuance.error.ledgerMismatched);
+        }
+
+        if (!schemaDetails) {
           throw new NotFoundException(ResponseMessages.bulkIssuance.error.invalidIdentifier);
         }
+        const { attributes, schemaLedgerId, name } = schemaDetails;
+        schemaResponse = { attributes, schemaLedgerId, name };
         fileName = `${schemaResponse.name}-${timestamp}.csv`;
       }
 
@@ -1214,12 +1226,12 @@ export class IssuanceService {
         fileName
       };
     } catch (error) {
-      this.logger.error(`error in downloading csv : ${error.response}`);
-      throw error;
+      this.logger.error(`error in downloading csv : ${JSON.stringify(error.response)}`);
+      throw new RpcException(error?.response ? error?.response : error);
     }
   }
 
-  async uploadCSVTemplate(importFileDetails: ImportFileDetails, requestId?: string): Promise<string> {
+  async uploadCSVTemplate(importFileDetails: ImportFileDetails, orgId: string, requestId?: string): Promise<string> {
     try {
       let credentialDetails;
       const credentialPayload: ICredentialPayload = {
@@ -1230,15 +1242,29 @@ export class IssuanceService {
         credentialType: '',
         schemaName: ''
       };
+
+      const orgDetails = await this.issuanceRepository.getAgentEndPoint(orgId);
+
       const { fileName, templateId, type, isValidateSchema } = importFileDetails;
       if (type === SchemaType.W3C_Schema) {
         credentialDetails = await this.issuanceRepository.getSchemaDetailsBySchemaIdentifier(templateId);
+
+        if (orgDetails?.ledgerId !== credentialDetails?.ledgerId) {
+          throw new BadRequestException(ResponseMessages.issuance.error.ledgerMismatched);
+        }
+
         credentialPayload.schemaLedgerId = credentialDetails.schemaLedgerId;
         credentialPayload.credentialDefinitionId = SchemaType.W3C_Schema;
         credentialPayload.credentialType = SchemaType.W3C_Schema;
         credentialPayload.schemaName = credentialDetails.name;
       } else if (type === SchemaType.INDY) {
         credentialDetails = await this.issuanceRepository.getCredentialDefinitionDetails(templateId);
+        const schemaDetails = await this.issuanceRepository.getSchemaDetails(credentialDetails.schemaLedgerId);
+
+        if (orgDetails?.ledgerId !== schemaDetails?.ledgerId) {
+          throw new BadRequestException(ResponseMessages.issuance.error.ledgerMismatched);
+        }
+
         credentialPayload.schemaLedgerId = credentialDetails.schemaLedgerId;
         credentialPayload.credentialDefinitionId = credentialDetails.credentialDefinitionId;
         credentialPayload.credentialType = SchemaType.INDY;
@@ -1771,14 +1797,14 @@ export class IssuanceService {
         };
 
         oobIssuancepayload = await createOobJsonldIssuancePayload(JsonldCredentialDetails, prettyVc);
+        oobIssuancepayload.isValidateSchema = jobDetails?.isValidateSchema;
       }
 
       const oobCredentials = await this.outOfBandCredentialOffer(
         oobIssuancepayload,
         jobDetails?.platformName,
         jobDetails?.organizationLogoUrl,
-        prettyVc,
-        jobDetails?.isValidateSchema
+        prettyVc
       );
       if (oobCredentials) {
         await this.issuanceRepository.deleteFileDataByJobId(jobDetails.id);

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -339,7 +339,8 @@ export const ResponseMessages = {
       cachedfileData: 'Cached file data does not exist',
       storeBulkData: 'Error while storing the bulk deata',
       issuanceRecordsNotFound: 'Issuance records does not exists',
-      removeIssuanceData: 'First you have to remove issuance data'
+      removeIssuanceData: 'First you have to remove issuance data',
+      ledgerMismatched: `Organization ledger mismatch detected. This template cannot be used. Please use a template created with the organization's specific ledger`
     }
   },
   verification: {


### PR DESCRIPTION
### What?
- Resolved below issues:

1). Indy organization was allowed to upload W3C schema csv for bulk issuance.
2). Indy organization was allowed to download W3C schema csv for bulk issuance.
3). Credential issuance succeeds with mismatched INDY orgId and W3C schema in bulk issue API.
4). Schema creation is successful, even if dataType is string, and if we provide properties for string dataType.
5). Unable to download csv template for INDY-based schemas in bulk issuance.
6). `isValidateSchema` conditions are not applicable for issuance using connection and issuance using email.