### PR TITLE
fix: trim requestId in issuance controller

### DIFF
--- a/apps/api-gateway/src/issuance/issuance.controller.ts
+++ b/apps/api-gateway/src/issuance/issuance.controller.ts
@@ -522,6 +522,7 @@ export class IssuanceController {
     @Body() fileDetails?: object,
     @UploadedFile() file?: Express.Multer.File
   ): Promise<Response> {
+    requestId = requestId.trim();
     const { credDefId } = query;
     clientDetails.userId = user.id;
     let reqPayload;


### PR DESCRIPTION
### Issue Fixed:

fix:Incorrect response received when space is added before requestId in the requestId parameter #1226

### Changes
Trimmed the requestId in the controller function of the API described in the issue