### PR TITLE
fix: handle invalid orgID with proper 400 error

### DIFF
--- a/apps/api-gateway/src/webhook/dtos/get-webhoook-dto.ts
+++ b/apps/api-gateway/src/webhook/dtos/get-webhoook-dto.ts
@@ -6,11 +6,11 @@ import { trim } from '@credebl/common/cast.helper';
 @ApiExtraModels()
 export class GetWebhookDto {
 
-    @ApiPropertyOptional({example: '2a041d6e-d24c-4ed9-b011-1cfc371a8b8e'})
-    @IsOptional()
+    @ApiProperty({example: '2a041d6e-d24c-4ed9-b011-1cfc371a8b8e'})
     @Transform(({ value }) => trim(value))
+    @IsNotEmpty({ message: 'Please provide the valid orgID' })
     @IsString({ message: 'Organization id must be in string format.' })
-    orgId?: string;
+    orgId: string;
 
     @ApiPropertyOptional({example: '3a041d6e-d24c-4ed9-b011-1cfc371a8b8e'})
     @IsOptional()


### PR DESCRIPTION
This PR fixes an issue where a space before an invalid `orgId` in the `GET /v1/webhooks/orgs/webhookurl` API was causing a 500 Internal Server Error.

# Fix

- The `orgId` is now trimmed using the `@Transform` decorator.
- Validation added using `@IsNotEmpty` and `@IsString` to return a 400 Bad Request if `orgId` is missing or invalid.

- Fixes #1220
