### PR TITLE
refactor: replace searchByText with search and update extendPagination handling

### DIFF
--- a/apps/api-gateway/src/credential-definition/dto/get-all-cred-defs.dto.ts
+++ b/apps/api-gateway/src/credential-definition/dto/get-all-cred-defs.dto.ts
@@ -5,35 +5,25 @@ import { SortValue } from '../../enum';
 import { Transform, Type } from 'class-transformer';
 import {  IsOptional, Max, Min } from 'class-validator';
 import { toNumber } from '@credebl/common/cast.helper';
+import { PaginationDto } from '@credebl/common/dtos/pagination.dto';
 
-export class GetAllCredDefsDto {
-    @ApiProperty({ required: false, default: 1 })
-    @IsOptional()
-    @Transform(({ value }) => toNumber(value))
-    pageNumber: number = 1;
+export class GetAllCredDefsDto extends PaginationDto{
+   
+    @ApiProperty({ required: false, example: 'id' })
+  @IsOptional()
+  sorting: string = 'id';
 
-    @ApiProperty({ required: false })
-    @IsOptional()
-    @Type(() => String)
-    searchByText: string = '';
+  @ApiProperty({
+    enum: [SortValue.DESC, SortValue.ASC],
+    required: false,
+    example: SortValue.DESC,
+  })
+  @IsOptional()
+  @IsEnum(SortValue)
+  sortByValue: string = SortValue.DESC;
 
-    @ApiProperty({ required: false, default: 10 })
-    @IsOptional()
-    @Transform(({ value }) => toNumber(value))
-    @Min(1, { message: 'Page size must be greater than 0' })
-    @Max(100, { message: 'Page size must be less than 100' })
-    pageSize: number = 10;
-
-    @ApiProperty({ required: false })
-    @IsOptional()
-    sorting: string = 'id'; 
-
-    @ApiProperty({ required: false })
-    @IsOptional()
-    sortByValue: string = SortValue.DESC;
-
-    @ApiProperty({ required: false })
-    @IsOptional()
-    revocable: boolean = true;
+  @ApiProperty({ required: false, example: true })
+  @IsOptional()
+  revocable: boolean = true;
 }
 

--- a/apps/api-gateway/src/interfaces/IConnectionSearch.interface.ts
+++ b/apps/api-gateway/src/interfaces/IConnectionSearch.interface.ts
@@ -5,7 +5,7 @@ export interface IConnectionSearchCriteria {
   pageSize: number;
   sortField: string;
   sortBy: string;
-  searchByText: string;
+  search: string;
   user?: IUserRequestInterface;
 }
 

--- a/apps/api-gateway/src/issuance/dtos/issuance.dto.ts
+++ b/apps/api-gateway/src/issuance/dtos/issuance.dto.ts
@@ -30,6 +30,7 @@ import { Transform, Type } from 'class-transformer';
 
 import { SortFields } from 'apps/connection/src/enum/connection.enum';
 import { trim } from '@credebl/common/cast.helper';
+import { PaginationDto } from '@credebl/common/dtos/pagination.dto';
 
 class Issuer {
   @ApiProperty()
@@ -492,33 +493,13 @@ export class OOBCredentialDtoWithEmail {
   orgId: string;
 }
 
-export class PreviewFileDetails {
-  @ApiProperty({ required: false, example: '1' })
-  @IsOptional()
-  pageNumber: number = 1;
-
-  @ApiProperty({ required: false, example: '10' })
-  @IsOptional()
-  pageSize: number = 10;
-
-  @ApiProperty({ required: false })
-  @IsOptional()
-  @Transform(({ value }) => trim(value))
-  @Type(() => String)
-  searchByText: string = '';
+export class PreviewFileDetails extends PaginationDto {
+  
 }
 
-export class FileParameter {
-  @ApiProperty({ required: false, example: '10' })
-  @IsOptional()
-  pageSize: number = 10;
-
-  @ApiProperty({ required: false, example: '1' })
-  @IsOptional()
-  pageNumber: number = 1;
-
-  @ApiProperty({
-    required: false
+export class FileParameter extends PaginationDto {
+   @ApiProperty({
+    required: false,
   })
   @Transform(({ value }) => trim(value))
   @IsOptional()
@@ -527,18 +508,12 @@ export class FileParameter {
 
   @ApiProperty({
     enum: [SortValue.DESC, SortValue.ASC],
-    required: false
+    required: false,
   })
   @Transform(({ value }) => trim(value))
   @IsOptional()
   @IsEnum(SortValue)
   sortBy: string = SortValue.DESC;
-
-  @ApiProperty({ required: false })
-  @IsOptional()
-  @Transform(({ value }) => trim(value))
-  @Type(() => String)
-  searchByText: string = '';
 }
 
 export class ClientDetails {

--- a/apps/api-gateway/src/schema/schema.controller.ts
+++ b/apps/api-gateway/src/schema/schema.controller.ts
@@ -143,10 +143,10 @@ export class SchemaController {
     @User() user: IUserRequestInterface
   ): Promise<Response> {
 
-    const { pageSize, searchByText, pageNumber, sortField, sortBy } = getAllSchemaDto;
+    const { pageSize, search, pageNumber, sortField, sortBy } = getAllSchemaDto;
     const schemaSearchCriteria: ISchemaSearchPayload = {
       pageNumber,
-      searchByText,
+      search,
       pageSize,
       sortField,
       sortBy

--- a/apps/api-gateway/src/webhook/dtos/get-webhoook-dto.ts
+++ b/apps/api-gateway/src/webhook/dtos/get-webhoook-dto.ts
@@ -6,11 +6,11 @@ import { trim } from '@credebl/common/cast.helper';
 @ApiExtraModels()
 export class GetWebhookDto {
 
-    @ApiPropertyOptional({example: '2a041d6e-d24c-4ed9-b011-1cfc371a8b8e'})
-    @IsOptional()
+    @ApiProperty({example: '2a041d6e-d24c-4ed9-b011-1cfc371a8b8e'})
     @Transform(({ value }) => trim(value))
+    @IsNotEmpty({ message: 'Please provide the valid orgID' })
     @IsString({ message: 'Organization id must be in string format.' })
-    orgId?: string;
+    orgId: string;
 
     @ApiPropertyOptional({example: '3a041d6e-d24c-4ed9-b011-1cfc371a8b8e'})
     @IsOptional()

--- a/apps/connection/src/interfaces/connection.interfaces.ts
+++ b/apps/connection/src/interfaces/connection.interfaces.ts
@@ -129,7 +129,7 @@ export interface IConnectionSearchCriteria {
   pageSize: number;
   sortField: string;
   sortBy: string;
-  searchByText: string;
+  search: string;
   user: IUserRequestInterface
 }
 


### PR DESCRIPTION
This PR addresses the following improvements in the connection-related files:

### 1. Replaced `searchByText` with `search`
- Updated all references of `searchByText` to `search` in:
  - `connection.service.ts`
  - `connection.interfaces.ts`
  - `iconnectionsearch.interface.ts`

### 2. Handled `extendPagination`
- Verified and updated the handling of `extendPagination` 


---
issue: #705







