### PR TITLE
Refactor AgentType enum: Replace 'AFJ' with 'Credo'

### DIFF
--- a/apps/agent-provisioning/src/agent-provisioning.service.ts
+++ b/apps/agent-provisioning/src/agent-provisioning.service.ts
@@ -23,7 +23,7 @@ export class AgentProvisioningService {
     try {
 
       const { containerName, externalIp, orgId, seed, walletName, walletPassword, walletStorageHost, walletStoragePassword, walletStoragePort, walletStorageUser, webhookEndpoint, agentType, protocol, credoImage, tenant, indyLedger, inboundEndpoint } = payload;
-      if (agentType === AgentType.AFJ) {
+      if (agentType === AgentType.Credo) {
         // The wallet provision command is used to invoke a shell script
         const walletProvision = `${process.cwd() + process.env.AFJ_AGENT_SPIN_UP} ${orgId} "${externalIp}" "${walletName}" "${walletPassword}" ${seed} ${webhookEndpoint} ${walletStorageHost} ${walletStoragePort} ${walletStorageUser} ${walletStoragePassword} ${containerName} ${protocol} ${tenant} ${credoImage} "${indyLedger}" ${inboundEndpoint} ${process.env.SCHEMA_FILE_SERVER_URL} ${process.env.AGENT_HOST} ${process.env.AWS_ACCOUNT_ID} ${process.env.S3_BUCKET_ARN} ${process.env.CLUSTER_NAME} ${process.env.TESKDEFINITION_FAMILY}`;
         const spinUpResponse: object = new Promise(async (resolve) => {

--- a/apps/agent-service/src/agent-service.service.ts
+++ b/apps/agent-service/src/agent-service.service.ts
@@ -414,7 +414,7 @@ export class AgentServiceService {
       walletStoragePassword: process.env.WALLET_STORAGE_PASSWORD || '',
       inboundEndpoint,
       containerName: orgData.name.split(' ').join('_'),
-      agentType: AgentType.AFJ,
+      agentType: AgentType.Credo,
       orgName: orgData?.name,
       indyLedger: escapedJsonString,
       credoImage: process.env.AFJ_VERSION || '',
@@ -862,7 +862,7 @@ export class AgentServiceService {
       // Get shared agent type
       const orgAgentTypeId = await this.agentServiceRepository.getOrgAgentTypeDetails(OrgAgentType.SHARED);
       // Get agent type details
-      const agentTypeId = await this.agentServiceRepository.getAgentTypeId(AgentType.AFJ);
+      const agentTypeId = await this.agentServiceRepository.getAgentTypeId(AgentType.Credo);
 
       const storeOrgAgentData: IStoreOrgAgentDetails = {
         did: tenantDetails.DIDCreationOption.did,

--- a/apps/agent-service/src/repositories/agent-service.repository.ts
+++ b/apps/agent-service/src/repositories/agent-service.repository.ts
@@ -297,7 +297,7 @@ export class AgentServiceRepository {
     try {
       const { id } = await this.prisma.agents_type.findFirstOrThrow({
         where: {
-          agent: AgentType.AFJ
+          agent: AgentType.Credo
         }
       });
       return id;

--- a/libs/enum/src/enum.ts
+++ b/libs/enum/src/enum.ts
@@ -26,8 +26,7 @@ export enum CredDefSortFields {
 }
 
 export enum AgentType {
-  // TODO: Change to Credo
-  AFJ = 'AFJ',
+  Credo = 'Credo',
   ACAPY = 'ACAPY'
 }
 


### PR DESCRIPTION
**What does this PR do?**
This pull request refactors the `AgentType` enum by replacing the outdated `'AFJ'` value with `'Credo'` in `libs/enum/src/enum.ts`. All usages of `AgentType.AFJ` and the string `'AFJ'` across the codebase have been updated to `AgentType.Credo` and `'Credo'` respectively. The lingering TODO comment has also been removed.

**Why is this change necessary?**
There was a TODO to update the agent type for consistency and clarity. Using the correct agent name avoids confusion and ensures uniform reference across services.

**What has changed?**
- `AgentType.AFJ` → `AgentType.Credo`
- `'AFJ'` string values replaced with `'Credo'`
- TODO comment removed

**How was this tested?**
All references and usages were carefully updated and verified. The test suite was executed to ensure no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the agent type from "AFJ" to "Credo" across the application, including all related logic and configuration.
- **Style**
  - Removed outdated comments referencing the previous agent type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->