### PR TITLE
fix: update upload-artifact-version to v4

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@v4
         with:
           name: sarif-file
           path: results.sarif


### PR DESCRIPTION
## What ?
- Updated upload-artifact action to use latest stable version (v4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Actions workflow to use the latest version of the artifact upload action for improved reliability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->