### PR TITLE
fix: update upload-artifact-version to v4 and artifact name in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,9 +59,9 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@v4
         with:
-          name: SARIF file
+          name: sarif-file
           path: results.sarif
           retention-days: 5
 


### PR DESCRIPTION
# What ?

- update upload-artifact-version to v4
- update artifact name in scorecard workflow