### PR TITLE
Feat/generate token for client

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -28,7 +28,7 @@ while read local_ref local_sha remote_ref remote_sha; do
       echo "${CYAN}ℹ️  Skipping merge commit $commit${RESET}"
       continue
     fi
-
+    sig_status=$(git log --format='%G?' -n 1 $commit)	
     # Currently only check for "N" - for no signature.
     if [ "$sig_status" = "N" ]; then
       unsigned_commits="$unsigned_commits $commit"
@@ -56,7 +56,7 @@ while read local_ref local_sha remote_ref remote_sha; do
         --exec 'if [ $(git rev-list --parents -n 1 HEAD | awk "{print NF-1}") -eq 1 ]; then git commit --amend -sS --no-edit; else echo "Skipping merge commit $(git rev-parse --short HEAD)"; fi'
 
       echo "${GREEN}✅ Earliest unsigned commit has been signed.${RESET}"
-      echo "Please push again: git push"
+      echo "Please push again: git push --force-with-lease"
       exit 1
     else
       echo "${YELLOW}You can manually sign commits using:${RESET}"
@@ -88,4 +88,4 @@ while read local_ref local_sha remote_ref remote_sha; do
   fi
 done
 
-echo "${GREEN}✅ All commits are signed and verified${RESET}"
+echo "${GREEN}✅ No unsigned commits found${RESET}"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -10,9 +10,6 @@ RESET="\033[0m"
 
 echo "🔒 Checking commit signatures..."
 
-# Get the email of the current user
-# CURRENT_EMAIL=$(git config user.email)
-
 while read local_ref local_sha remote_ref remote_sha; do
   # Determine range of commits
   if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
@@ -31,13 +28,6 @@ while read local_ref local_sha remote_ref remote_sha; do
       echo "${CYAN}ℹ️  Skipping merge commit $commit${RESET}"
       continue
     fi
-
-    # Skip commits not authored by the current user
-    # author_email=$(git log -1 --format='%ae' $commit)
-    # if [ "$author_email" != "$CURRENT_EMAIL" ]; then
-    #   echo "${CYAN}ℹ️  Skipping commit $commit authored by $author_email${RESET}"
-    #   continue
-    # fi
 
     # Currently only check for "N" - for no signature.
     if [ "$sig_status" = "N" ]; then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -10,6 +10,9 @@ RESET="\033[0m"
 
 echo "🔒 Checking commit signatures..."
 
+# Get the email of the current user
+# CURRENT_EMAIL=$(git config user.email)
+
 while read local_ref local_sha remote_ref remote_sha; do
   # Determine range of commits
   if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
@@ -29,7 +32,12 @@ while read local_ref local_sha remote_ref remote_sha; do
       continue
     fi
 
-    sig_status=$(git log --format='%G?' -n 1 $commit)
+    # Skip commits not authored by the current user
+    # author_email=$(git log -1 --format='%ae' $commit)
+    # if [ "$author_email" != "$CURRENT_EMAIL" ]; then
+    #   echo "${CYAN}ℹ️  Skipping commit $commit authored by $author_email${RESET}"
+    #   continue
+    # fi
 
     # Currently only check for "N" - for no signature.
     if [ "$sig_status" = "N" ]; then
@@ -58,13 +66,12 @@ while read local_ref local_sha remote_ref remote_sha; do
         --exec 'if [ $(git rev-list --parents -n 1 HEAD | awk "{print NF-1}") -eq 1 ]; then git commit --amend -sS --no-edit; else echo "Skipping merge commit $(git rev-parse --short HEAD)"; fi'
 
       echo "${GREEN}✅ Earliest unsigned commit has been signed.${RESET}"
-      echo "Please push again: git push --force-with-lease"
+      echo "Please push again: git push"
       exit 1
     else
       echo "${YELLOW}You can manually sign commits using:${RESET}"
       echo
       # Latest commit (HEAD)
-      head_commit=$(git rev-parse HEAD)
       echo "  - For the latest commit (HEAD):"
       echo "      git commit --amend -sS --no-edit"
       echo
@@ -75,7 +82,6 @@ while read local_ref local_sha remote_ref remote_sha; do
       echo "  - For the earliest unsigned commit $short_hash (skipping merge commits):"
       echo "      git rebase --onto $parent_commit $parent_commit \\"
       echo "        --exec 'if [ \$(git rev-list --parents -n 1 HEAD | awk \"{print NF-1}\") -eq 1 ]; then git commit --amend -sS --no-edit; else echo \"Skipping merge commit \$(git rev-parse --short HEAD)\"; fi'"
-
       echo
       echo "Then push normally with:"
       echo "      git push"

--- a/apps/api-gateway/src/organization/dtos/client-token.dto.ts
+++ b/apps/api-gateway/src/organization/dtos/client-token.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class ClientTokenDto {
+  @ApiProperty()
+  @IsString({ message: 'orgId must be in string format.' })
+  orgId: string;
+
+  @ApiProperty()
+  @IsString({ message: 'clientId must be in string format.' })
+  clientId: string;
+
+  @ApiProperty()
+  @IsString({ message: 'clientSecret must be in string format.' })
+  clientSecret: string;
+
+  @ApiProperty()
+  @IsString({ message: 'grantType must be in string format.' })
+  grantType?: string = 'client_credentials';
+}

--- a/apps/api-gateway/src/organization/dtos/client-token.dto.ts
+++ b/apps/api-gateway/src/organization/dtos/client-token.dto.ts
@@ -7,6 +7,10 @@ export class ClientTokenDto {
   orgId: string;
 
   @ApiProperty()
+  @IsString({ message: 'clientAlias must be in string format.' })
+  clientAlias: string;
+
+  @ApiProperty()
   @IsString({ message: 'clientId must be in string format.' })
   clientId: string;
 

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -792,6 +792,7 @@ export class OrganizationController {
   }
 
   @Post('/generateIssuerApiToken')
+  @ApiExcludeEndpoint()
   @ApiOperation({
     summary: 'Generate API Token for the issuer',
     description: 'Generate API Token for the issuer'

--- a/apps/api-gateway/src/organization/organization.controller.ts
+++ b/apps/api-gateway/src/organization/organization.controller.ts
@@ -54,6 +54,7 @@ import { UserAccessGuard } from '../authz/guards/user-access-guard';
 import { GetAllOrganizationsDto } from './dtos/get-organizations.dto';
 import { PrimaryDid } from './dtos/set-primary-did.dto';
 import { TrimStringParamPipe } from '@credebl/common/cast.helper';
+import { ClientTokenDto } from './dtos/client-token.dto';
 
 @UseFilters(CustomExceptionFilter)
 @Controller('orgs')
@@ -788,5 +789,16 @@ export class OrganizationController {
       message: ResponseMessages.organisation.success.orgInvitationDeleted
     };
     return res.status(HttpStatus.OK).json(finalResponse);
+  }
+
+  @Post('/generateIssuerApiToken')
+  @ApiOperation({
+    summary: 'Generate API Token for the issuer',
+    description: 'Generate API Token for the issuer'
+  })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
+  async generateApiToken(@Body() clientTokenDto: ClientTokenDto, @Res() res: Response): Promise<Response> {
+    const finalResponse = await this.organizationService.generateClientApiToken(clientTokenDto);
+    return res.status(HttpStatus.OK).header('Content-Type', 'application/json').send(finalResponse);
   }
 }

--- a/apps/api-gateway/src/organization/organization.service.ts
+++ b/apps/api-gateway/src/organization/organization.service.ts
@@ -24,6 +24,7 @@ import { GetAllOrganizationsDto } from './dtos/get-organizations.dto';
 import { PrimaryDid } from './dtos/set-primary-did.dto';
 import { NATSClient } from '@credebl/common/NATSClient';
 import { ClientProxy } from '@nestjs/microservices';
+import { ClientTokenDto } from './dtos/client-token.dto';
 
 @Injectable()
 export class OrganizationService extends BaseService {
@@ -237,5 +238,8 @@ export class OrganizationService extends BaseService {
     const base64Data = base64Image.replace(/^data:image\/\w+;base64,/, '');
     const imageBuffer = Buffer.from(base64Data, 'base64');
     return imageBuffer;
+  }
+  async generateClientApiToken(clientTokenDto: ClientTokenDto): Promise<{ token: string }> {
+    return this.natsClient.sendNatsMessage(this.serviceProxy, 'generate-client-api-token', clientTokenDto);
   }
 }

--- a/apps/organization/dtos/client-token.dto.ts
+++ b/apps/organization/dtos/client-token.dto.ts
@@ -1,0 +1,6 @@
+export class ClientTokenDto {
+  orgId: string;
+  clientId: string;
+  clientSecret: string;
+  grantType?: string = 'client_credentials';
+}

--- a/apps/organization/dtos/client-token.dto.ts
+++ b/apps/organization/dtos/client-token.dto.ts
@@ -1,5 +1,6 @@
 export class ClientTokenDto {
   orgId: string;
+  clientAlias: string;
   clientId: string;
   clientSecret: string;
   grantType?: string = 'client_credentials';

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -662,6 +662,7 @@ export class OrganizationRepository {
             countryId: true,
             stateId: true,
             cityId: true,
+            appLaunchDetails: true,
             userOrgRoles: {
               where: {
                 orgRole: {

--- a/apps/organization/src/organization.controller.ts
+++ b/apps/organization/src/organization.controller.ts
@@ -4,12 +4,27 @@ import { OrganizationService } from './organization.service';
 import { CreateOrganizationDto } from '../dtos/create-organization.dto';
 import { BulkSendInvitationDto } from '../dtos/send-invitation.dto';
 import { UpdateInvitationDto } from '../dtos/update-invitation.dt';
-import { IDidList, IGetOrgById, IGetOrganization, IOrgDetails, IUpdateOrganization, Payload } from '../interfaces/organization.interface';
-import { IOrgCredentials, IOrganizationInvitations, IOrganization, IOrganizationDashboard, IDeleteOrganization, IOrgActivityCount } from '@credebl/common/interfaces/organization.interface';
+import {
+  IDidList,
+  IGetOrgById,
+  IGetOrganization,
+  IOrgDetails,
+  IUpdateOrganization,
+  Payload
+} from '../interfaces/organization.interface';
+import {
+  IOrgCredentials,
+  IOrganizationInvitations,
+  IOrganization,
+  IOrganizationDashboard,
+  IDeleteOrganization,
+  IOrgActivityCount
+} from '@credebl/common/interfaces/organization.interface';
 import { organisation, user } from '@prisma/client';
 import { IAccessTokenData } from '@credebl/common/interfaces/interface';
 import { IClientRoles } from '@credebl/client-registration/interfaces/client.interface';
 import { IOrgRoles } from 'libs/org-roles/interfaces/org-roles.interface';
+import { ClientTokenDto } from '../dtos/client-token.dto';
 
 @Controller()
 export class OrganizationController {
@@ -23,7 +38,9 @@ export class OrganizationController {
    */
 
   @MessagePattern({ cmd: 'create-organization' })
-  async createOrganization(@Body() payload: { createOrgDto: CreateOrganizationDto; userId: string, keycloakUserId: string }): Promise<organisation> {
+  async createOrganization(
+    @Body() payload: { createOrgDto: CreateOrganizationDto; userId: string; keycloakUserId: string }
+  ): Promise<organisation> {
     return this.organizationService.createOrganization(payload.createOrgDto, payload.userId, payload.keycloakUserId);
   }
 
@@ -34,17 +51,19 @@ export class OrganizationController {
    */
 
   @MessagePattern({ cmd: 'set-primary-did' })
-  async setPrimaryDid(@Body() payload: { orgId:string, did:string, id:string}): Promise<string> {
+  async setPrimaryDid(@Body() payload: { orgId: string; did: string; id: string }): Promise<string> {
     return this.organizationService.setPrimaryDid(payload.orgId, payload.did, payload.id);
   }
 
   /**
-   * 
-   * @param payload 
+   *
+   * @param payload
    * @returns organization client credentials
    */
   @MessagePattern({ cmd: 'create-org-credentials' })
-  async createOrgCredentials(@Body() payload: { orgId: string; userId: string, keycloakUserId: string }): Promise<IOrgCredentials> {
+  async createOrgCredentials(
+    @Body() payload: { orgId: string; userId: string; keycloakUserId: string }
+  ): Promise<IOrgCredentials> {
     return this.organizationService.createOrgCredentials(payload.orgId, payload.userId, payload.keycloakUserId);
   }
 
@@ -55,7 +74,11 @@ export class OrganizationController {
    */
 
   @MessagePattern({ cmd: 'update-organization' })
-  async updateOrganization(payload: { updateOrgDto: IUpdateOrganization; userId: string, orgId: string }): Promise<organisation> {
+  async updateOrganization(payload: {
+    updateOrgDto: IUpdateOrganization;
+    userId: string;
+    orgId: string;
+  }): Promise<organisation> {
     return this.organizationService.updateOrganization(payload.updateOrgDto, payload.userId, payload.orgId);
   }
 
@@ -65,7 +88,7 @@ export class OrganizationController {
    * @returns organization's did list
    */
   @MessagePattern({ cmd: 'fetch-organization-dids' })
-  async getOrgDidList(payload: {orgId:string}): Promise<IDidList[]> {
+  async getOrgDidList(payload: { orgId: string }): Promise<IDidList[]> {
     return this.organizationService.getOrgDidList(payload.orgId);
   }
 
@@ -75,9 +98,7 @@ export class OrganizationController {
    * @returns Get created organization details
    */
   @MessagePattern({ cmd: 'get-organizations' })
-  async getOrganizations(
-    @Body() payload: { userId: string} & Payload
-  ): Promise<IGetOrganization> {
+  async getOrganizations(@Body() payload: { userId: string } & Payload): Promise<IGetOrganization> {
     const { userId, pageNumber, pageSize, search, role } = payload;
     return this.organizationService.getOrganizations(userId, pageNumber, pageSize, search, role);
   }
@@ -87,12 +108,9 @@ export class OrganizationController {
    * @returns Get created organization details
    */
   @MessagePattern({ cmd: 'get-organizations-count' })
-  async countTotalOrgs(
-    @Body() payload: { userId: string}
-  ): Promise<number> {
-    
+  async countTotalOrgs(@Body() payload: { userId: string }): Promise<number> {
     const { userId } = payload;
-    
+
     return this.organizationService.countTotalOrgs(userId);
   }
 
@@ -100,9 +118,7 @@ export class OrganizationController {
    * @returns Get public organization details
    */
   @MessagePattern({ cmd: 'get-public-organizations' })
-  async getPublicOrganizations(
-    @Body() payload: Payload
-  ): Promise<IGetOrganization> {
+  async getPublicOrganizations(@Body() payload: Payload): Promise<IGetOrganization> {
     const { pageNumber, pageSize, search } = payload;
     return this.organizationService.getPublicOrganizations(pageNumber, pageSize, search);
   }
@@ -113,13 +129,13 @@ export class OrganizationController {
    * @returns Get created organization details
    */
   @MessagePattern({ cmd: 'get-organization-by-id' })
-  async getOrganization(@Body() payload: { orgId: string; userId: string}): Promise<IGetOrgById> {
+  async getOrganization(@Body() payload: { orgId: string; userId: string }): Promise<IGetOrgById> {
     return this.organizationService.getOrganization(payload.orgId);
   }
-/**
- * @param orgSlug 
- * @returns organization details
- */
+  /**
+   * @param orgSlug
+   * @returns organization details
+   */
   @MessagePattern({ cmd: 'get-organization-public-profile' })
   async getPublicProfile(payload: { orgSlug }): Promise<IGetOrgById> {
     return this.organizationService.getPublicProfile(payload);
@@ -131,9 +147,7 @@ export class OrganizationController {
    * @returns Get created invitation details
    */
   @MessagePattern({ cmd: 'get-invitations-by-orgId' })
-  async getInvitationsByOrgId(
-    @Body() payload: { orgId: string } & Payload
-  ): Promise<IOrganizationInvitations> {
+  async getInvitationsByOrgId(@Body() payload: { orgId: string } & Payload): Promise<IOrganizationInvitations> {
     return this.organizationService.getInvitationsByOrgId(
       payload.orgId,
       payload.pageNumber,
@@ -143,11 +157,11 @@ export class OrganizationController {
   }
 
   /**
-   * @returns Get org-roles 
+   * @returns Get org-roles
    */
 
   @MessagePattern({ cmd: 'get-org-roles' })
-  async getOrgRoles(payload: {orgId: string, user: user}): Promise<IClientRoles[]> {
+  async getOrgRoles(payload: { orgId: string; user: user }): Promise<IClientRoles[]> {
     return this.organizationService.getOrgRoles(payload.orgId, payload.user);
   }
 
@@ -163,7 +177,7 @@ export class OrganizationController {
    */
   @MessagePattern({ cmd: 'send-invitation' })
   async createInvitation(
-    @Body() payload: { bulkInvitationDto: BulkSendInvitationDto; userId: string, userEmail: string }
+    @Body() payload: { bulkInvitationDto: BulkSendInvitationDto; userId: string; userEmail: string }
   ): Promise<string> {
     return this.organizationService.createInvitation(payload.bulkInvitationDto, payload.userId, payload.userEmail);
   }
@@ -198,7 +212,7 @@ export class OrganizationController {
    */
 
   @MessagePattern({ cmd: 'update-user-roles' })
-  async updateUserRoles(payload: { orgId: string; roleIds: string[]; userId: string}): Promise<boolean> {
+  async updateUserRoles(payload: { orgId: string; roleIds: string[]; userId: string }): Promise<boolean> {
     return this.organizationService.updateUserRoles(payload.orgId, payload.roleIds, payload.userId);
   }
 
@@ -212,9 +226,9 @@ export class OrganizationController {
     return this.organizationService.getOrganizationActivityCount(payload.orgId, payload.userId);
   }
 
-/**
- * @returns organization profile details
- */
+  /**
+   * @returns organization profile details
+   */
   @MessagePattern({ cmd: 'fetch-organization-profile' })
   async getOrgPofile(payload: { orgId: string }): Promise<organisation> {
     return this.organizationService.getOrgPofile(payload.orgId);
@@ -231,27 +245,27 @@ export class OrganizationController {
   }
 
   @MessagePattern({ cmd: 'get-organization-details' })
-  async getOrgData(payload: { orgId: string; }): Promise<organisation> {
+  async getOrgData(payload: { orgId: string }): Promise<organisation> {
     return this.organizationService.getOrgDetails(payload.orgId);
   }
-  
+
   @MessagePattern({ cmd: 'delete-organization' })
-  async deleteOrganization(payload: { orgId: string, user: user }): Promise<IDeleteOrganization> {
+  async deleteOrganization(payload: { orgId: string; user: user }): Promise<IDeleteOrganization> {
     return this.organizationService.deleteOrganization(payload.orgId, payload.user);
   }
 
   @MessagePattern({ cmd: 'delete-org-client-credentials' })
-  async deleteOrganizationCredentials(payload: { orgId: string, user: user }): Promise<string> {
+  async deleteOrganizationCredentials(payload: { orgId: string; user: user }): Promise<string> {
     return this.organizationService.deleteClientCredentials(payload.orgId, payload.user);
   }
 
   @MessagePattern({ cmd: 'delete-organization-invitation' })
-  async deleteOrganizationInvitation(payload: { orgId: string; invitationId: string; }): Promise<boolean> {
+  async deleteOrganizationInvitation(payload: { orgId: string; invitationId: string }): Promise<boolean> {
     return this.organizationService.deleteOrganizationInvitation(payload.orgId, payload.invitationId);
   }
 
   @MessagePattern({ cmd: 'authenticate-client-credentials' })
-  async clientLoginCredentails(payload: { clientId: string; clientSecret: string;}): Promise<IAccessTokenData> {
+  async clientLoginCredentails(payload: { clientId: string; clientSecret: string }): Promise<IAccessTokenData> {
     return this.organizationService.clientLoginCredentails(payload);
   }
 
@@ -261,12 +275,12 @@ export class OrganizationController {
   }
 
   @MessagePattern({ cmd: 'get-agent-type-by-org-agent-type-id' })
-  async getAgentTypeByAgentTypeId(payload: {orgAgentTypeId: string}): Promise<string> {
+  async getAgentTypeByAgentTypeId(payload: { orgAgentTypeId: string }): Promise<string> {
     return this.organizationService.getAgentTypeByAgentTypeId(payload.orgAgentTypeId);
   }
 
   @MessagePattern({ cmd: 'get-org-roles-details' })
-  async getOrgRolesDetails(payload: {roleName: string}): Promise<object> {
+  async getOrgRolesDetails(payload: { roleName: string }): Promise<object> {
     return this.organizationService.getOrgRolesDetails(payload.roleName);
   }
 
@@ -286,7 +300,12 @@ export class OrganizationController {
   }
 
   @MessagePattern({ cmd: 'get-org-agents-and-user-roles' })
-  async getOrgAgentDetailsForEcosystem(payload: {orgIds: string[], search: string}): Promise<IOrgDetails> {
+  async getOrgAgentDetailsForEcosystem(payload: { orgIds: string[]; search: string }): Promise<IOrgDetails> {
     return this.organizationService.getOrgAgentDetailsForEcosystem(payload);
+  }
+
+  @MessagePattern({ cmd: 'generate-client-api-token' })
+  async generateClientApiToken(payload: ClientTokenDto): Promise<{ token: string }> {
+    return this.organizationService.generateClientApiToken(payload);
   }
 }

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -2033,16 +2033,13 @@ export class OrganizationService {
 
   async generateClientApiToken(generateTokenDetails: ClientTokenDto): Promise<{ token: string }> {
     try {
-      this.logger.debug(`generateTokenDetails ::: ${JSON.stringify(generateTokenDetails)}`);
       const orgDetails = await this.organizationRepository.getOrganizationDetails(generateTokenDetails.orgId);
-      this.logger.debug(`orgDetails ::: ${JSON.stringify(orgDetails)}`);
       if (!orgDetails) {
         throw new NotFoundException(ResponseMessages.organisation.error.orgNotFound);
       }
       // Step:1 generate the token using admin credentials
       const adminTokenDetails =
         await this.clientRegistrationService.generateTokenUsingAdminCredentials(generateTokenDetails);
-      this.logger.debug(`adminTokenDetails ::: ${JSON.stringify(adminTokenDetails)}`);
       if (!adminTokenDetails?.access_token) {
         throw new InternalServerErrorException(ResponseMessages.organisation.error.adminTokenDetails);
       }
@@ -2054,11 +2051,9 @@ export class OrganizationService {
       if (!clientDetails || 0 === clientDetails.length) {
         throw new NotFoundException(ResponseMessages.organisation.error.clientDetails);
       }
-      this.logger.debug(`clientDetails ::: ${JSON.stringify(clientDetails)}`);
       const { secret } = clientDetails[0];
       //step3: generate the token using client id and secret
       const authenticationResult = await this.authenticateClientKeycloak(generateTokenDetails.orgId, secret);
-      this.logger.debug(`authenticationResult ::: ${JSON.stringify(authenticationResult)}`);
       return { token: authenticationResult.access_token };
     } catch (error) {
       this.logger.error(`in generating issuer api token : ${JSON.stringify(error)}`);

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -2037,6 +2037,16 @@ export class OrganizationService {
       if (!orgDetails) {
         throw new NotFoundException(ResponseMessages.organisation.error.orgNotFound);
       }
+      // Add validation for client alias
+      const clientIdKey = `${generateTokenDetails.clientAlias}_KEYCLOAK_MANAGEMENT_CLIENT_ID`;
+
+      if (!process.env[clientIdKey]) {
+        throw new NotFoundException(ResponseMessages.organisation.error.clientDetails);
+      }
+      const getDecryptedAlias = await this.commonService.decryptPassword(process.env[clientIdKey]);
+      if (generateTokenDetails.clientAlias.toLowerCase() !== getDecryptedAlias.toLowerCase()) {
+        throw new NotFoundException(ResponseMessages.organisation.error.missMachingAlias);
+      }
       // Step:1 generate the token using admin credentials
       const adminTokenDetails =
         await this.clientRegistrationService.generateTokenUsingAdminCredentials(generateTokenDetails);

--- a/libs/client-registration/src/client-registration.service.ts
+++ b/libs/client-registration/src/client-registration.service.ts
@@ -736,13 +736,11 @@ export class ClientRegistrationService {
         'Content-Type': 'application/x-www-form-urlencoded'
       }
     };
-    this.logger.debug(`generateTokenUsingAdminCredentials payload ${JSON.stringify(payload)}`);
     const generatetedTokenDetails = await this.commonService.httpPost(
       await this.keycloakUrlService.GenerateTokenUsingAdminCredentials(realmName),
       qs.stringify(payload),
       config
     );
-    this.logger.debug(`generatetedTokenDetails ${JSON.stringify(generatetedTokenDetails)}`);
     return generatetedTokenDetails;
   }
 
@@ -753,9 +751,6 @@ export class ClientRegistrationService {
       await this.keycloakUrlService.GetClientURL(realmName, clientId),
       this.getAuthHeader(token)
     );
-
-    this.logger.debug(`clientDetails ${JSON.stringify(clientDetails)}`);
-
     return clientDetails;
   }
 }

--- a/libs/client-registration/src/client-registration.service.ts
+++ b/libs/client-registration/src/client-registration.service.ts
@@ -729,7 +729,7 @@ export class ClientRegistrationService {
     const payload = {
       client_id: clientDetails.clientId,
       client_secret: clientDetails.clientSecret,
-      grant_type: clientDetails.grantType
+      grant_type: clientDetails.grantType ?? 'client_credentials'
     };
     const config = {
       headers: {

--- a/libs/client-registration/src/client-registration.service.ts
+++ b/libs/client-registration/src/client-registration.service.ts
@@ -736,12 +736,12 @@ export class ClientRegistrationService {
         'Content-Type': 'application/x-www-form-urlencoded'
       }
     };
-    const generatetedTokenDetails = await this.commonService.httpPost(
+    const generatedTokenDetails = await this.commonService.httpPost(
       await this.keycloakUrlService.GetSATURL(realmName),
       qs.stringify(payload),
       config
     );
-    return generatetedTokenDetails;
+    return generatedTokenDetails;
   }
 
   async fetchClientDetails(clientId: string, token: string) {

--- a/libs/client-registration/src/client-registration.service.ts
+++ b/libs/client-registration/src/client-registration.service.ts
@@ -4,21 +4,23 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
-import { BadRequestException, Injectable, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import * as qs from 'qs';
 
+import { BadRequestException, Injectable, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+
 import { ClientCredentialTokenPayloadDto } from './dtos/client-credential-token-payload.dto';
+import { ClientTokenDto } from './dtos/client-token.dto';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { CommonService } from '@credebl/common';
 import { CreateUserDto } from './dtos/create-user.dto';
-import { JwtService } from '@nestjs/jwt';
-import { KeycloakUrlService } from '@credebl/keycloak-url';
-import { accessTokenPayloadDto } from './dtos/accessTokenPayloadDto';
-import { userTokenPayloadDto } from './dtos/userTokenPayloadDto';
-import { KeycloakUserRegistrationDto } from 'apps/user/dtos/keycloak-register.dto';
-import { ResponseMessages } from '@credebl/common/response-messages';
 import { IClientRoles } from './interfaces/client.interface';
 import { IFormattedResponse } from '@credebl/common/interfaces/interface';
+import { JwtService } from '@nestjs/jwt';
+import { KeycloakUrlService } from '@credebl/keycloak-url';
+import { KeycloakUserRegistrationDto } from 'apps/user/dtos/keycloak-register.dto';
+import { ResponseMessages } from '@credebl/common/response-messages';
+import { accessTokenPayloadDto } from './dtos/accessTokenPayloadDto';
+import { userTokenPayloadDto } from './dtos/userTokenPayloadDto';
 
 @Injectable()
 export class ClientRegistrationService {
@@ -720,5 +722,40 @@ export class ClientRegistrationService {
     this.logger.debug(`userInfo ${JSON.stringify(userInfo)}`);
 
     return userInfo;
+  }
+
+  async generateTokenUsingAdminCredentials(clientDetails: ClientTokenDto) {
+    const realmName = process.env.KEYCLOAK_REALM;
+    const payload = {
+      client_id: clientDetails.clientId,
+      client_secret: clientDetails.clientSecret,
+      grant_type: clientDetails.grantType
+    };
+    const config = {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    };
+    this.logger.debug(`generateTokenUsingAdminCredentials payload ${JSON.stringify(payload)}`);
+    const generatetedTokenDetails = await this.commonService.httpPost(
+      await this.keycloakUrlService.GenerateTokenUsingAdminCredentials(realmName),
+      qs.stringify(payload),
+      config
+    );
+    this.logger.debug(`generatetedTokenDetails ${JSON.stringify(generatetedTokenDetails)}`);
+    return generatetedTokenDetails;
+  }
+
+  async fetchClientDetails(clientId: string, token: string) {
+    const realmName = process.env.KEYCLOAK_REALM;
+
+    const clientDetails = await this.commonService.httpGet(
+      await this.keycloakUrlService.GetClientURL(realmName, clientId),
+      this.getAuthHeader(token)
+    );
+
+    this.logger.debug(`clientDetails ${JSON.stringify(clientDetails)}`);
+
+    return clientDetails;
   }
 }

--- a/libs/client-registration/src/client-registration.service.ts
+++ b/libs/client-registration/src/client-registration.service.ts
@@ -737,7 +737,7 @@ export class ClientRegistrationService {
       }
     };
     const generatetedTokenDetails = await this.commonService.httpPost(
-      await this.keycloakUrlService.GenerateTokenUsingAdminCredentials(realmName),
+      await this.keycloakUrlService.GetSATURL(realmName),
       qs.stringify(payload),
       config
     );

--- a/libs/client-registration/src/dtos/client-token.dto.ts
+++ b/libs/client-registration/src/dtos/client-token.dto.ts
@@ -1,0 +1,6 @@
+export class ClientTokenDto {
+  orgId: string;
+  clientId: string;
+  clientSecret: string;
+  grantType?: string = 'client_credentials';
+}

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -133,7 +133,7 @@ export const ResponseMessages = {
       MaximumOrgsLimit: 'Limit reached: You can be associated with or create maximum 10 organizations.',
       adminTokenDetails: 'Error in generating admin token details',
       clientDetails: 'Error in fetching client details',
-      missMachingAlias: 'Client alias does not match the registered alias'
+      invalidClientCredentials: 'Invalid client credentials'
     }
   },
 

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -132,7 +132,7 @@ export const ResponseMessages = {
       organizationNotFound: 'Organization not found',
       MaximumOrgsLimit: 'Limit reached: You can be associated with or create maximum 10 organizations.',
       adminTokenDetails: 'Error in generating admin token details',
-      clientDetails: ' Error in fetching client details'
+      clientDetails: 'Error in fetching client details'
     }
   },
 

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -132,7 +132,8 @@ export const ResponseMessages = {
       organizationNotFound: 'Organization not found',
       MaximumOrgsLimit: 'Limit reached: You can be associated with or create maximum 10 organizations.',
       adminTokenDetails: 'Error in generating admin token details',
-      clientDetails: 'Error in fetching client details'
+      clientDetails: 'Error in fetching client details',
+      missMachingAlias: 'Client alias does not match the registered alias'
     }
   },
 

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -130,7 +130,9 @@ export const ResponseMessages = {
       primaryDid: 'This DID is already set to primary DID',
       didNotFound: 'DID does not exist in organiation',
       organizationNotFound: 'Organization not found',
-      MaximumOrgsLimit: 'Limit reached: You can be associated with or create maximum 10 organizations.'
+      MaximumOrgsLimit: 'Limit reached: You can be associated with or create maximum 10 organizations.',
+      adminTokenDetails: 'Error in generating admin token details',
+      clientDetails: ' Error in fetching client details'
     }
   },
 

--- a/libs/keycloak-url/src/keycloak-url.service.ts
+++ b/libs/keycloak-url/src/keycloak-url.service.ts
@@ -2,131 +2,77 @@ import { Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class KeycloakUrlService {
-    private readonly logger = new Logger('KeycloakUrlService');
+  private readonly logger = new Logger('KeycloakUrlService');
 
-
-    async createUserURL(
-        realm: string
-      ):Promise<string> {
-
-        return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/users`;
-    }
-
-    async getUserByUsernameURL(
-      realm: string,
-      username: string
-    ):Promise<string> {
-
-      return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/users?username=${username}`;
+  async createUserURL(realm: string): Promise<string> {
+    return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/users`;
   }
 
-    async GetUserInfoURL(
-        realm: string,
-        userid: string
-      ):Promise<string> {
-
-        return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/users/${userid}`;
-    }
-
-    async GetSATURL(
-        realm: string
-      ):Promise<string> {
-
-        return `${process.env.KEYCLOAK_DOMAIN}realms/${realm}/protocol/openid-connect/token`;
-    }
-    
-    async ResetPasswordURL(
-      realm: string,
-      userid: string
-    ):Promise<string> {
-
-      return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/users/${userid}/reset-password`;
+  async getUserByUsernameURL(realm: string, username: string): Promise<string> {
+    return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/users?username=${username}`;
   }
 
+  async GetUserInfoURL(realm: string, userid: string): Promise<string> {
+    return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/users/${userid}`;
+  }
 
-  async CreateRealmURL():Promise<string> {
+  async GetSATURL(realm: string): Promise<string> {
+    return `${process.env.KEYCLOAK_DOMAIN}realms/${realm}/protocol/openid-connect/token`;
+  }
+
+  async ResetPasswordURL(realm: string, userid: string): Promise<string> {
+    return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/users/${userid}/reset-password`;
+  }
+
+  async CreateRealmURL(): Promise<string> {
     return `${process.env.KEYCLOAK_DOMAIN}admin/realms`;
   }
 
-  async createClientURL(
-    realm: string
-  ):Promise<string> {
-
+  async createClientURL(realm: string): Promise<string> {
     return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/clients`;
   }
 
-  async GetClientURL(
-    realm: string,
-    clientid: string
-  ):Promise<string> {
-
+  async GetClientURL(realm: string, clientid: string): Promise<string> {
     return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/clients?clientId=${clientid}`;
-  } 
+  }
 
-  async GetClientSecretURL(
-    realm: string,
-    clientid: string
-  ):Promise<string> {
-
+  async GetClientSecretURL(realm: string, clientid: string): Promise<string> {
     return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/clients/${clientid}/client-secret`;
   }
 
-  async GetClientRoleURL(
-    realm: string,
-    clientid: string,
-    roleName = ''
-  ):Promise<string> {
-
+  async GetClientRoleURL(realm: string, clientid: string, roleName = ''): Promise<string> {
     if ('' === roleName) {
       return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/clients/${clientid}/roles`;
     }
 
     return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/clients/${clientid}/roles/${roleName}`;
-
   }
 
-  async GetRealmRoleURL(
-    realm: string,
-    roleName = ''
-  ):Promise<string> {
-
+  async GetRealmRoleURL(realm: string, roleName = ''): Promise<string> {
     if ('' === roleName) {
       return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/roles`;
     }
 
     return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/roles/${roleName}`;
-
   }
 
-  async GetClientUserRoleURL(
-    realm: string,
-    userId: string,
-    clientId?: string
-  ):Promise<string> {
-
+  async GetClientUserRoleURL(realm: string, userId: string, clientId?: string): Promise<string> {
     if (clientId) {
       return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/users/${userId}/role-mappings/clients/${clientId}`;
     }
 
     return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/users/${userId}/role-mappings/realm`;
-
   }
-  
 
-  async GetClientIdpURL(
-    realm: string,
-    idp: string
-  ):Promise<string> {
-
+  async GetClientIdpURL(realm: string, idp: string): Promise<string> {
     return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/clients/${idp}`;
   }
 
-  async GetClient(
-    realm: string,
-    clientId: string
-  ):Promise<string> {
-
+  async GetClient(realm: string, clientId: string): Promise<string> {
     return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/clients?clientId=${clientId}`;
   }
 
+  async GenerateTokenUsingAdminCredentials(realm: string): Promise<string> {
+    return `${process.env.KEYCLOAK_DOMAIN}realms/${realm}/protocol/openid-connect/token`;
+  }
 }

--- a/libs/keycloak-url/src/keycloak-url.service.ts
+++ b/libs/keycloak-url/src/keycloak-url.service.ts
@@ -71,8 +71,4 @@ export class KeycloakUrlService {
   async GetClient(realm: string, clientId: string): Promise<string> {
     return `${process.env.KEYCLOAK_DOMAIN}admin/realms/${realm}/clients?clientId=${clientId}`;
   }
-
-  async GenerateTokenUsingAdminCredentials(realm: string): Promise<string> {
-    return `${process.env.KEYCLOAK_DOMAIN}realms/${realm}/protocol/openid-connect/token`;
-  }
 }

--- a/libs/prisma-service/prisma/migrations/20250925060521_added_app_launch_details_column_in_organization/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20250925060521_added_app_launch_details_column_in_organization/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "organisation" ADD COLUMN     "appLaunchDetails" JSONB;

--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -133,6 +133,7 @@ model organisation {
   clientId              String?                 @db.VarChar(500)
   clientSecret          String?                 @db.VarChar(500)
   registrationNumber    String?                 @db.VarChar(100)
+  appLaunchDetails      Json?
   countryId             Int?
   countries             countries?              @relation(fields: [countryId], references: [id])
   stateId               Int?


### PR DESCRIPTION
## What?
API for generate client token for end user using orgId and admin client details.
Add new column for storing the app launcher details.
## How?
Wrote the API to get admin client details and org id using this details generate the institute token and return it
Added new column in organization table to store the app launcher details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New endpoint to generate client API tokens for organizations.

* **Improvements**
  * Standardized client-token request format across services.
  * Organization responses now include app launch details.
  * More reliable token-generation flow with improved admin/client token handling, external lookups, and clearer error messages for token/client failures.

* **Chores**
  * Database migration added to support app launch details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->