### PR TITLE
fix: add client alias to reset password email for logo display

### DIFF
--- a/apps/api-gateway/src/authz/dtos/forgot-password.dto.ts
+++ b/apps/api-gateway/src/authz/dtos/forgot-password.dto.ts
@@ -2,37 +2,45 @@ import { IsEmail, IsNotEmpty, IsOptional, IsString, IsUrl } from 'class-validato
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import {  trim } from '@credebl/common/cast.helper';
+import { trim } from '@credebl/common/cast.helper';
 
 export class ForgotPasswordDto {
-    @ApiProperty({ example: 'awqx@yopmail.com' })
-    @IsEmail({}, { message: 'Please provide a valid email' })
-    @IsNotEmpty({ message: 'Email is required' })
-    @IsString({ message: 'Email should be a string' })
-    @Transform(({ value }) => trim(value))
-    email: string;
+  @ApiProperty({ example: 'awqx@yopmail.com' })
+  @IsEmail({}, { message: 'Please provide a valid email' })
+  @IsNotEmpty({ message: 'Email is required' })
+  @IsString({ message: 'Email should be a string' })
+  @Transform(({ value }) => trim(value))
+  email: string;
 
-    @ApiPropertyOptional({ example: 'https://example.com/logo.png' })
-    @Transform(({ value }) => trim(value))
-    @IsOptional()
-    @IsUrl({
-    // eslint-disable-next-line camelcase 
-        require_protocol: true,
-    // eslint-disable-next-line camelcase
+  @ApiPropertyOptional({ example: 'https://example.com/logo.png' })
+  @Transform(({ value }) => trim(value))
+  @IsOptional()
+  @IsUrl(
+    {
+      // eslint-disable-next-line camelcase
+      require_protocol: true,
+      // eslint-disable-next-line camelcase
       require_tld: true
     },
-    { message: 'brandLogoUrl should be a valid URL' })
-    brandLogoUrl?: string;
+    { message: 'brandLogoUrl should be a valid URL' }
+  )
+  brandLogoUrl?: string;
 
-    @ApiPropertyOptional({ example: 'MyPlatform' })
-    @Transform(({ value }) => trim(value))
-    @IsOptional()
-    @IsString({ message: 'platformName should be string' })
-    platformName?: string;
+  @ApiPropertyOptional({ example: 'MyPlatform' })
+  @Transform(({ value }) => trim(value))
+  @IsOptional()
+  @IsString({ message: 'platformName should be string' })
+  platformName?: string;
 
-    @ApiPropertyOptional({ example: 'https://0.0.0.0:5000' })
-    @Transform(({ value }) => trim(value))
-    @IsOptional()
-    @IsString({ message: 'endpoint should be string' })
-    endpoint?: string;
+  @ApiPropertyOptional({ example: 'https://0.0.0.0:5000' })
+  @Transform(({ value }) => trim(value))
+  @IsOptional()
+  @IsString({ message: 'endpoint should be string' })
+  endpoint?: string;
+
+  @ApiPropertyOptional({ example: 'VERIFIER' })
+  @Transform(({ value }) => trim(value))
+  @IsOptional()
+  @IsString({ message: 'clientAlias should be string' })
+  clientAlias?: string;
 }

--- a/apps/user/interfaces/user.interface.ts
+++ b/apps/user/interfaces/user.interface.ts
@@ -221,6 +221,7 @@ export interface IUserForgotPassword {
   brandLogoUrl?: string;
   platformName?: string;
   endpoint?: string;
+  clientAlias?: string;
 }
 export interface IIssueCertificate {
   courseCode: string;

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -621,7 +621,7 @@ export class UserService {
    * @returns
    */
   async forgotPassword(forgotPasswordDto: IUserForgotPassword): Promise<IResetPasswordResponse> {
-    const { email, brandLogoUrl, platformName, endpoint } = forgotPasswordDto;
+    const { email, brandLogoUrl, platformName, endpoint, clientAlias } = forgotPasswordDto;
     try {
       this.validateEmail(email.toLowerCase());
       const userData = await this.userRepository.checkUserExist(email.toLowerCase());
@@ -644,7 +644,14 @@ export class UserService {
       }
 
       try {
-        await this.sendEmailForResetPassword(email, brandLogoUrl, platformName, endpoint, tokenCreated.token);
+        await this.sendEmailForResetPassword(
+          email,
+          brandLogoUrl,
+          platformName,
+          endpoint,
+          tokenCreated.token,
+          clientAlias
+        );
       } catch (error) {
         throw new InternalServerErrorException(ResponseMessages.user.error.emailSend);
       }
@@ -670,7 +677,8 @@ export class UserService {
     brandLogoUrl: string,
     platformName: string,
     endpoint: string,
-    verificationCode: string
+    verificationCode: string,
+    clientAlias: string | undefined
   ): Promise<boolean> {
     try {
       const platformConfigData = await this.prisma.platform_config.findMany();
@@ -688,7 +696,8 @@ export class UserService {
         platform,
         brandLogoUrl,
         endpoint,
-        verificationCode
+        verificationCode,
+        clientAlias
       );
       const isEmailSent = await sendEmail(emailData);
       if (isEmailSent) {

--- a/apps/user/templates/reset-password-template.ts
+++ b/apps/user/templates/reset-password-template.ts
@@ -1,12 +1,19 @@
 import * as url from 'url';
 export class URLUserResetPasswordTemplate {
-  public getUserResetPasswordTemplate(email: string, platform: string, brandLogoUrl: string, uiEndpoint: string, verificationCode: string): string {
+  public getUserResetPasswordTemplate(
+    email: string,
+    platform: string,
+    brandLogoUrl: string,
+    uiEndpoint: string,
+    verificationCode: string,
+    clientAlias?: string
+  ): string {
     const endpoint = uiEndpoint || process.env.FRONT_END_URL;
 
     const apiUrl = url.parse(
-      `${endpoint}/reset-password?verificationCode=${verificationCode}&email=${encodeURIComponent(email)}`
+      `${endpoint}/reset-password?verificationCode=${verificationCode}&email=${encodeURIComponent(email)}${clientAlias ? `&clientAlias=${clientAlias}` : ''}`
     );
-    
+
     const logoUrl = brandLogoUrl || process.env.BRAND_LOGO;
     const poweredBy = platform || process.env.POWERED_BY;
 
@@ -60,7 +67,6 @@ export class URLUserResetPasswordTemplate {
           </div>
       </body>
       </html>`;
-
     } catch (error) {}
   }
 }


### PR DESCRIPTION
# What

- included client alias to reset password mail to manage the logo while user visits the page from other apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional client alias support to password reset workflows. This enables client-specific customization of reset password emails by allowing the client identifier to be included in the reset flow and incorporated into the reset link for personalized email content delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->