### PR TITLE
feat: notice URL support for issuance

### DIFF
--- a/apps/api-gateway/src/oid4vc-issuance/dtos/issuer-sessions.dto.ts
+++ b/apps/api-gateway/src/oid4vc-issuance/dtos/issuer-sessions.dto.ts
@@ -186,6 +186,14 @@ export class CreateOidcCredentialOfferDto {
   @IsIn(['preAuthorizedCodeFlow', 'authorizationCodeFlow'])
   authorizationType!: 'preAuthorizedCodeFlow' | 'authorizationCodeFlow';
 
+  @ApiPropertyOptional({
+    example: 'https://dev-consent.sovio.id/api/consent-notice/CN-OGL70CWB',
+    description: 'Optional notice URL to attach in the response when multiple credentials are offered.'
+  })
+  @IsOptional()
+  @IsUrl()
+  noticeUrl?: string;
+
   issuerId?: string;
 }
 

--- a/apps/api-gateway/src/oid4vc-issuance/dtos/oid4vc-issuer-template.dto.ts
+++ b/apps/api-gateway/src/oid4vc-issuance/dtos/oid4vc-issuer-template.dto.ts
@@ -282,6 +282,14 @@ export class CreateCredentialTemplateDto {
   @Type(() => AppearanceDto)
   appearance?: AppearanceDto;
 
+  @ApiPropertyOptional({
+    example: 'https://dev-consent.sovio.id/api/consent-notice/CN-OGL70CWB',
+    description: 'Optional consent notice URL associated with this credential template'
+  })
+  @IsOptional()
+  @IsString()
+  noticeUrl?: string;
+
   issuerId: string;
 }
 

--- a/apps/oid4vc-issuance/interfaces/oid4vc-issuer-sessions.interfaces.ts
+++ b/apps/oid4vc-issuance/interfaces/oid4vc-issuer-sessions.interfaces.ts
@@ -47,6 +47,7 @@ export interface CreateOidcCredentialOffer {
   // e.g. "abc-gov"
   authenticationType: AuthenticationType; // only option selector
   credentials: CredentialRequest[]; // one or more credentials
+  noticeUrl?: string;
 }
 
 export interface GetAllCredentialOffer {

--- a/apps/oid4vc-issuance/interfaces/oid4vc-template.interfaces.ts
+++ b/apps/oid4vc-issuance/interfaces/oid4vc-template.interfaces.ts
@@ -22,6 +22,7 @@ export interface CreateCredentialTemplate {
   appearance?: Prisma.JsonValue;
   issuerId: string;
   template: SdJwtTemplate | MdocTemplate;
+  noticeUrl?: string;
 }
 
 export interface UpdateCredentialTemplate extends Partial<CreateCredentialTemplate> {}

--- a/apps/oid4vc-issuance/src/oid4vc-issuance.service.ts
+++ b/apps/oid4vc-issuance/src/oid4vc-issuance.service.ts
@@ -442,7 +442,9 @@ export class Oid4vcIssuanceService {
             canBeRevoked: template.canBeRevoked,
             attributes: template.attributes,
             appearance: template.appearance,
-            issuerId: template.issuerId
+            issuerId: template.issuerId,
+            signerOption: template.signerOption,
+            noticeUrl: template.noticeUrl ?? null
           };
           await this.oid4vcIssuanceRepository.updateTemplate(templateId, rollbackPayload);
           this.logger.log(`Rolled back template ${templateId} to previous state after agent error`);
@@ -627,16 +629,19 @@ export class Oid4vcIssuanceService {
         throw new NotFoundException(ResponseMessages.oidcIssuerSession.error.errorCreateOffer);
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response = createCredentialOfferOnAgent.response as any;
+      const { response } = createCredentialOfferOnAgent;
 
-      if (1 === filterTemplateIds.length) {
-        const template = await this.oid4vcIssuanceRepository.getTemplateById(filterTemplateIds[0]);
-        if (template?.noticeUrl) {
-          response.noticeUrl = template.noticeUrl;
+      if (null !== response) {
+        if (1 === filterTemplateIds.length) {
+          const template = await this.oid4vcIssuanceRepository.getTemplateById(filterTemplateIds[0]);
+          if (template?.noticeUrl) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (response as any).noticeUrl = template.noticeUrl;
+          }
+        } else if (createOidcCredentialOffer.noticeUrl) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (response as any).noticeUrl = createOidcCredentialOffer.noticeUrl;
         }
-      } else if (createOidcCredentialOffer.noticeUrl) {
-        response.noticeUrl = createOidcCredentialOffer.noticeUrl;
       }
 
       return response;

--- a/apps/oid4vc-issuance/src/oid4vc-issuance.service.ts
+++ b/apps/oid4vc-issuance/src/oid4vc-issuance.service.ts
@@ -309,7 +309,7 @@ export class Oid4vcIssuanceService {
   ): Promise<credential_templates> {
     try {
       //TODO: add revert mechanism if agent call fails
-      const { name, description, format, canBeRevoked, appearance, signerOption } = credentialTemplate;
+      const { name, description, format, canBeRevoked, appearance, signerOption, noticeUrl } = credentialTemplate;
 
       const checkNameExist = await this.oid4vcIssuanceRepository.getTemplateByNameForIssuer(name, issuerId);
       if (0 < checkNameExist.length) {
@@ -323,7 +323,8 @@ export class Oid4vcIssuanceService {
         attributes: instanceToPlain(credentialTemplate.template),
         appearance: appearance ?? {},
         issuerId,
-        signerOption
+        signerOption,
+        noticeUrl: noticeUrl ?? null
       };
       // Persist in DB
       const createdTemplate = await this.oid4vcIssuanceRepository.createTemplate(issuerId, metadata);
@@ -625,7 +626,19 @@ export class Oid4vcIssuanceService {
         throw new NotFoundException(ResponseMessages.oidcIssuerSession.error.errorCreateOffer);
       }
 
-      return createCredentialOfferOnAgent.response;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const response = createCredentialOfferOnAgent.response as any;
+
+      if (1 === filterTemplateIds.length) {
+        const template = await this.oid4vcIssuanceRepository.getTemplateById(filterTemplateIds[0]);
+        if (template?.noticeUrl) {
+          response.noticeUrl = template.noticeUrl;
+        }
+      } else if (createOidcCredentialOffer.noticeUrl) {
+        response.noticeUrl = createOidcCredentialOffer.noticeUrl;
+      }
+
+      return response;
     } catch (error) {
       const errorResponse = ErrorHandler.categorize(error, 'Failed to create credential offer');
       this.logger.error(

--- a/apps/oid4vc-issuance/src/oid4vc-issuance.service.ts
+++ b/apps/oid4vc-issuance/src/oid4vc-issuance.service.ts
@@ -394,7 +394,7 @@ export class Oid4vcIssuanceService {
         ...updateCredentialTemplate,
         ...(issuerId ? { issuerId } : {})
       };
-      const { name, description, format, canBeRevoked, appearance, signerOption } = normalized;
+      const { name, description, format, canBeRevoked, appearance, signerOption, noticeUrl } = normalized;
       const attributes = instanceToPlain(normalized.template);
 
       const payload = {
@@ -405,7 +405,8 @@ export class Oid4vcIssuanceService {
         ...(attributes !== undefined ? { attributes } : {}),
         ...(appearance !== undefined ? { appearance } : {}),
         ...(issuerId ? { issuerId } : {}),
-        ...(signerOption !== undefined ? { signerOption } : {})
+        ...(signerOption !== undefined ? { signerOption } : {}),
+        ...(noticeUrl !== undefined ? { noticeUrl } : {})
       };
 
       const updatedTemplate = await this.oid4vcIssuanceRepository.updateTemplate(templateId, payload);

--- a/libs/prisma-service/prisma/migrations/20260326140323_add_notice_url_to_credential_templates/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260326140323_add_notice_url_to_credential_templates/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "credential_templates" ADD COLUMN     "noticeUrl" TEXT;

--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -651,6 +651,8 @@ model credential_templates {
   issuerId String      @db.Uuid
   issuer   oidc_issuer @relation(fields: [issuerId], references: [id])
 
+  noticeUrl    String?
+
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
   signerOption SignerOption


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional notice URLs can now be added to credential offers and templates. Provided URLs are validated and surface with the credential data so recipients can see an associated notice link.
* **Chores**
  * Database schema and migration added to persist notice URLs, enabling storage and retrieval for existing and new templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->