### PR TITLE
feat: noAuth support for oid4vc issuance

### DIFF
--- a/apps/api-gateway/src/oid4vc-issuance/dtos/issuer-sessions.dto.ts
+++ b/apps/api-gateway/src/oid4vc-issuance/dtos/issuer-sessions.dto.ts
@@ -181,12 +181,12 @@ export class CreateOidcCredentialOfferDto {
 
   @ApiProperty({
     example: 'preAuthorizedCodeFlow',
-    enum: ['preAuthorizedCodeFlow', 'authorizationCodeFlow'],
+    enum: ['preAuthorizedCodeFlow', 'authorizationCodeFlow', 'noAuth'],
     description: 'Authorization type'
   })
   @IsString()
-  @IsIn(['preAuthorizedCodeFlow', 'authorizationCodeFlow'])
-  authorizationType!: 'preAuthorizedCodeFlow' | 'authorizationCodeFlow';
+  @IsIn(['preAuthorizedCodeFlow', 'authorizationCodeFlow', 'noAuth'])
+  authorizationType!: 'preAuthorizedCodeFlow' | 'authorizationCodeFlow' | 'noAuth';
 
   @ApiPropertyOptional({
     example: 'https://dev-consent.sovio.id/api/consent-notice/CN-OGL70CWB',

--- a/apps/oid4vc-issuance/interfaces/oid4vc-issuer-sessions.interfaces.ts
+++ b/apps/oid4vc-issuance/interfaces/oid4vc-issuer-sessions.interfaces.ts
@@ -21,8 +21,8 @@ export interface ISignerOption {
 }
 
 export enum AuthenticationType {
-  PRE_AUTHORIZED_CODE = 'pre-authorized_code',
-  AUTHORIZATION_CODE = 'authorization_code',
+  PRE_AUTHORIZED_CODE = 'preAuthorizedCodeFlow',
+  AUTHORIZATION_CODE = 'authorizationCodeFlow',
   NO_AUTH = 'noAuth'
 }
 

--- a/apps/oid4vc-issuance/interfaces/oid4vc-issuer-sessions.interfaces.ts
+++ b/apps/oid4vc-issuance/interfaces/oid4vc-issuer-sessions.interfaces.ts
@@ -22,7 +22,8 @@ export interface ISignerOption {
 
 export enum AuthenticationType {
   PRE_AUTHORIZED_CODE = 'pre-authorized_code',
-  AUTHORIZATION_CODE = 'authorization_code'
+  AUTHORIZATION_CODE = 'authorization_code',
+  NO_AUTH = 'noAuth'
 }
 
 /* ---------------------------------------------------------

--- a/apps/oid4vc-issuance/libs/helpers/credential-sessions.builder.ts
+++ b/apps/oid4vc-issuance/libs/helpers/credential-sessions.builder.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types, camelcase */
 import { credential_templates, SignerOption } from '@prisma/client';
-import { GetAllCredentialOffer, ISignerOption } from '../../interfaces/oid4vc-issuer-sessions.interfaces';
+import {
+  AuthenticationType,
+  GetAllCredentialOffer,
+  ISignerOption
+} from '../../interfaces/oid4vc-issuer-sessions.interfaces';
 import { CredentialFormat } from '@credebl/enum/enum';
 import {
   CredentialAttribute,
@@ -50,6 +54,7 @@ export interface CredentialRequestDtoLike {
 
 export interface CreateOidcCredentialOfferDtoLike {
   credentials: CredentialRequestDtoLike[];
+  authorizationType?: string;
   preAuthorizedCodeFlowConfig?: {
     txCode: { description?: string; length: number; input_mode: 'numeric' | 'text' | 'alphanumeric' };
     authorizationServerUrl: string;
@@ -103,7 +108,7 @@ export type CredentialOfferPayload = BuiltCredentialOfferBase &
   (
     | {
         preAuthorizedCodeFlowConfig: {
-          txCode: { description?: string; length: number; input_mode: 'numeric' | 'text' | 'alphanumeric' } | undefined;
+          txCode?: { description?: string; length: number; input_mode: 'numeric' | 'text' | 'alphanumeric' };
           authorizationServerUrl?: string;
         };
         authorizationCodeFlowConfig?: never;
@@ -503,8 +508,16 @@ export function buildCredentialOfferPayload(
 
   // Determine which authorization flow to return:
   // Priority:
-  // 1) If issuerDetails.authorizationServerUrl is provided, return preAuthorizedCodeFlowConfig using DEFAULT_TXCODE
-  // 2) Else fall back to flows present in DTO (still enforce XOR)
+  // 1) If authorizationType is 'noAuth', return empty preAuthorizedCodeFlowConfig (no txCode, no authorizationServerUrl)
+  // 2) If issuerDetails.authorizationServerUrl is provided, return preAuthorizedCodeFlowConfig using DEFAULT_TXCODE
+  // 3) Else fall back to flows present in DTO (still enforce XOR)
+  if (dto.authorizationType === AuthenticationType.NO_AUTH) {
+    return {
+      ...baseEnvelope,
+      preAuthorizedCodeFlowConfig: {}
+    };
+  }
+
   const overrideAuthorizationServerUrl = issuerDetails?.authorizationServerUrl;
   if (overrideAuthorizationServerUrl) {
     if ('string' !== typeof overrideAuthorizationServerUrl || '' === overrideAuthorizationServerUrl.trim()) {
@@ -513,7 +526,7 @@ export function buildCredentialOfferPayload(
     return {
       ...baseEnvelope,
       preAuthorizedCodeFlowConfig: {
-        txCode: DEFAULT_TXCODE, // Pass undefined to enable no auth implementation, TODO: Need to make it configuarble.
+        txCode: DEFAULT_TXCODE,
         authorizationServerUrl: overrideAuthorizationServerUrl
       }
     };


### PR DESCRIPTION
#### What
- noAuth support for oid4vc issuance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "no authentication" issuance mode: requests can opt into a no-auth flow in addition to pre-authorized and authorization-code flows. When selected, issuance is simplified (skips authorization steps and returns a minimal pre-authorized offer). The issuance request payload accepts an optional authorization-type field to select this mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->