### PR TITLE
feat: expose multiple Swagger UI endpoints grouped by modules

### DIFF
--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -2,8 +2,7 @@ import { otelSDK } from './tracer';
 import * as dotenv from 'dotenv';
 import * as express from 'express';
 
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import { OpenAPIObject } from '@nestjs/swagger';
+import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import { Logger, VERSION_NEUTRAL, VersioningType } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
@@ -89,64 +88,60 @@ async function bootstrap(): Promise<void> {
   });
 
   // Create Swagger document
- let document = SwaggerModule.createDocument(app, options);
-try {
-  const ecosystemFilter = app.get(EcosystemSwaggerFilter);
-  document = await ecosystemFilter.filterDocument(document);
-} catch (err) {
-  Logger.warn('Skipping EcosystemSwaggerFilter due to error', err as Error);
-}
-
-// 🔹 Helper to filter APIs by tag
-
-
-function filterByTags(doc: OpenAPIObject, tagNames: string[]): OpenAPIObject {
-  const filteredPaths: OpenAPIObject['paths'] = {};
-
-  for (const [path, methods] of Object.entries(doc.paths)) {
-    for (const [method, operation] of Object.entries(methods)) {
-      if (
-        operation.tags &&
-        operation.tags.some((tag: string) => tagNames.includes(tag))
-      ) {
-        if (!filteredPaths[path]) {
-          filteredPaths[path] = {};
-        }
-        filteredPaths[path][method] = operation;
-      }
-    }
+  let document = SwaggerModule.createDocument(app, options);
+  try {
+    const ecosystemFilter = app.get(EcosystemSwaggerFilter);
+    document = await ecosystemFilter.filterDocument(document);
+  } catch (err) {
+    Logger.warn('Skipping EcosystemSwaggerFilter due to error', err as Error);
   }
 
-  return {
-    ...doc,
-    paths: filteredPaths
-  };
-}
-// 🔹 Create separate documents
-const didcommDoc = filterByTags(document, [
-  'connections',
-  'verifications'
-]);
+  // Filter operations by tag into a standalone Swagger document
+  function filterByTags(doc: OpenAPIObject, tagNames: string[]): OpenAPIObject {
+    const filteredPaths: OpenAPIObject['paths'] = {};
 
-const oid4vcDoc = filterByTags(document, [
-  'OID4VC',
-  'OID4VP'
-]);
+    for (const [path, methods] of Object.entries(doc.paths)) {
+      for (const [method, operation] of Object.entries(methods)) {
+        if (operation.tags && operation.tags.some((tag: string) => tagNames.includes(tag))) {
+          if (!filteredPaths[path]) {
+            filteredPaths[path] = {};
+          }
+          filteredPaths[path][method] = operation;
+        }
+      }
+    }
 
-const utilsDoc = filterByTags(document, [
-  'utilities',
-  'ledgers',
-  'webhooks',
-  'geolocation',
-  'notification'
-]);
-// 🔹 Default full Swagger
-SwaggerModule.setup('api', app, document);
+    return {
+      ...doc,
+      paths: filteredPaths
+    };
+  }
 
-// 🔹 New grouped Swagger UIs
-SwaggerModule.setup('api/didcomm', app, didcommDoc);
-SwaggerModule.setup('api/oid4vc', app, oid4vcDoc);
-SwaggerModule.setup('api/utils', app, utilsDoc);
+  // Credential APIs are grouped under DIDComm rather than as a standalone section
+  const didcommDoc = filterByTags(document, [
+    'connections',
+    'verifications',
+    'credentials',
+    'credential-definitions',
+    'revocation-registry',
+    'schemas'
+  ]);
+
+  const oid4vcDoc = filterByTags(document, ['OID4VC', 'OID4VP']);
+
+  const authDoc = filterByTags(document, ['auth']);
+
+  // Platform and Webhook APIs are excluded from the Utils section
+  const utilsDoc = filterByTags(document, ['utilities', 'ledgers', 'geolocation', 'notification']);
+
+  // Default full Swagger
+  SwaggerModule.setup('api', app, document);
+
+  // Grouped Swagger UIs
+  SwaggerModule.setup('api/didcomm', app, didcommDoc);
+  SwaggerModule.setup('api/oid4vc', app, oid4vcDoc);
+  SwaggerModule.setup('api/auth', app, authDoc);
+  SwaggerModule.setup('api/utils', app, utilsDoc);
   const httpAdapter: HttpAdapterHost = app.get(HttpAdapterHost) as HttpAdapterHost;
   app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));
   const { ENABLE_CORS_IP_LIST } = process.env || {};
@@ -172,6 +167,9 @@ SwaggerModule.setup('api/utils', app, utilsDoc);
   app.use(express.static('invoice-pdf'));
   app.use(express.static('uploadedFiles/bulk-verification-templates'));
   app.use(express.static('uploadedFiles/import'));
+  app.use('/uploadedFiles/dev-org-logo', express.static('uploadedFiles/dev-org-logo'));
+  app.use('/uploadedFiles/demo-shortening-url', express.static('uploadedFiles/demo-shortening-url'));
+
   // Use custom updatable global pipes
   const reflector = app.get(Reflector);
   app.useGlobalPipes(new UpdatableValidationPipe(reflector, { whitelist: true, transform: true }));

--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -122,16 +122,23 @@ function filterByTags(doc: any, tagNames: string[]) {
   };
 }
 // 🔹 Create separate documents
-const didcommDoc = filterByTags(document, ['connection', 'issuance', 'verification']);
-const oid4vcDoc = filterByTags(document, ['oid4vc-issuance', 'oid4vc-verification']);
-const utilsDoc = filterByTags(document, [
-  'utility',
-  'ledger',
-  'webhook',
-  'geo-location',
-  'notification'
+const didcommDoc = filterByTags(document, [
+  'connections',
+  'verifications'
 ]);
 
+const oid4vcDoc = filterByTags(document, [
+  'OID4VC',
+  'OID4VP'
+]);
+
+const utilsDoc = filterByTags(document, [
+  'utilities',
+  'ledgers',
+  'webhooks',
+  'geolocation',
+  'notification'
+]);
 // 🔹 Default full Swagger
 SwaggerModule.setup('api', app, document);
 

--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -88,15 +88,57 @@ async function bootstrap(): Promise<void> {
   });
 
   // Create Swagger document
-  let document = SwaggerModule.createDocument(app, options);
-  try {
-    const ecosystemFilter = app.get(EcosystemSwaggerFilter);
-    document = await ecosystemFilter.filterDocument(document);
-  } catch (err) {
-    Logger.warn('Skipping EcosystemSwaggerFilter due to error', err as Error);
+ let document = SwaggerModule.createDocument(app, options);
+try {
+  const ecosystemFilter = app.get(EcosystemSwaggerFilter);
+  document = await ecosystemFilter.filterDocument(document);
+} catch (err) {
+  Logger.warn('Skipping EcosystemSwaggerFilter due to error', err as Error);
+}
+
+// 🔹 Helper to filter APIs by tag
+function filterByTags(doc: any, tagNames: string[]) {
+  const filteredPaths: any = {};
+
+  for (const path in doc.paths) {
+    const methods = doc.paths[path];
+
+    for (const method in methods) {
+      const operation = methods[method];
+
+      if (
+        operation.tags &&
+        operation.tags.some((tag: string) => tagNames.includes(tag))
+      ) {
+        if (!filteredPaths[path]) filteredPaths[path] = {};
+        filteredPaths[path][method] = operation;
+      }
+    }
   }
 
-  SwaggerModule.setup('api', app, document);
+  return {
+    ...doc,
+    paths: filteredPaths
+  };
+}
+// 🔹 Create separate documents
+const didcommDoc = filterByTags(document, ['connection', 'issuance', 'verification']);
+const oid4vcDoc = filterByTags(document, ['oid4vc-issuance', 'oid4vc-verification']);
+const utilsDoc = filterByTags(document, [
+  'utility',
+  'ledger',
+  'webhook',
+  'geo-location',
+  'notification'
+]);
+
+// 🔹 Default full Swagger
+SwaggerModule.setup('api', app, document);
+
+// 🔹 New grouped Swagger UIs
+SwaggerModule.setup('api/didcomm', app, didcommDoc);
+SwaggerModule.setup('api/oid4vc', app, oid4vcDoc);
+SwaggerModule.setup('api/utils', app, utilsDoc);
   const httpAdapter: HttpAdapterHost = app.get(HttpAdapterHost) as HttpAdapterHost;
   app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));
   const { ENABLE_CORS_IP_LIST } = process.env || {};

--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -3,6 +3,7 @@ import * as dotenv from 'dotenv';
 import * as express from 'express';
 
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { OpenAPIObject } from '@nestjs/swagger';
 import { Logger, VERSION_NEUTRAL, VersioningType } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
@@ -97,20 +98,20 @@ try {
 }
 
 // 🔹 Helper to filter APIs by tag
-function filterByTags(doc: any, tagNames: string[]) {
-  const filteredPaths: any = {};
 
-  for (const path in doc.paths) {
-    const methods = doc.paths[path];
 
-    for (const method in methods) {
-      const operation = methods[method];
+function filterByTags(doc: OpenAPIObject, tagNames: string[]): OpenAPIObject {
+  const filteredPaths: OpenAPIObject['paths'] = {};
 
+  for (const [path, methods] of Object.entries(doc.paths)) {
+    for (const [method, operation] of Object.entries(methods)) {
       if (
         operation.tags &&
         operation.tags.some((tag: string) => tagNames.includes(tag))
       ) {
-        if (!filteredPaths[path]) filteredPaths[path] = {};
+        if (!filteredPaths[path]) {
+          filteredPaths[path] = {};
+        }
         filteredPaths[path][method] = operation;
       }
     }


### PR DESCRIPTION
## Summary
This PR introduces multiple Swagger UI endpoints grouped by feature/domain to improve API discoverability and developer experience.

## Changes
- Added tag-based filtering utility to split Swagger document
- Exposed new endpoints:
  - /api/didcomm
  - /api/oid4vc
  - /api/utils
- Preserved existing /api endpoint for backward compatibility

## Notes
- Grouping is based on existing module tags (connection, issuance, verification, oid4vc, utility, etc.)
- This improves navigation and reduces clutter in API documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API Gateway Swagger documentation is now split across multiple specialized endpoints: the full API remains at `/api`, with additional focused docs at `/api/didcomm`, `/api/oid4vc`, `/api/auth`, and `/api/utils` for easier discovery.
  * Added explicit access routes for uploaded demo assets (dev logo and demo shortening URL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->