### PR TITLE
fix: add missing orgId column to issued_oid4vc_credentials table

### DIFF
--- a/libs/prisma-service/prisma/migrations/20260504110536_add_orgid_and_isprimary_in_oidc_issuer/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260504110536_add_orgid_and_isprimary_in_oidc_issuer/migration.sql
@@ -1,6 +1,11 @@
 -- AlterTable
-ALTER TABLE "oidc_issuer" ADD COLUMN     "isPrimary" BOOLEAN NOT NULL DEFAULT false,
-ADD COLUMN     "orgId" UUID;
+ALTER TABLE "oidc_issuer" ADD COLUMN IF NOT EXISTS "isPrimary" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "oidc_issuer" ADD COLUMN IF NOT EXISTS "orgId" UUID;
 
 -- AddForeignKey
-ALTER TABLE "oidc_issuer" ADD CONSTRAINT "oidc_issuer_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "organisation"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'oidc_issuer_orgId_fkey') THEN
+        ALTER TABLE "oidc_issuer" ADD CONSTRAINT "oidc_issuer_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "organisation"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+    END IF;
+END $$;

--- a/libs/prisma-service/prisma/migrations/20260507140000_add_orgId_to_issued_credentials/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260507140000_add_orgId_to_issued_credentials/migration.sql
@@ -1,0 +1,18 @@
+-- AlterTable
+ALTER TABLE "issued_oid4vc_credentials" ADD COLUMN IF NOT EXISTS "orgId" UUID;
+
+-- AddForeignKey
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'issued_oid4vc_credentials_orgId_fkey') THEN
+        ALTER TABLE "issued_oid4vc_credentials" ADD CONSTRAINT "issued_oid4vc_credentials_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "organisation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- CreateIndex
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relname = 'issued_oid4vc_credentials_orgId_issuanceSessionId_idx') THEN
+        CREATE INDEX "issued_oid4vc_credentials_orgId_issuanceSessionId_idx" ON "issued_oid4vc_credentials"("orgId", "issuanceSessionId");
+    END IF;
+END $$;


### PR DESCRIPTION
- Add missing orgId column to issued_oid4vc_credentials table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema to associate OIDC issuers with organizations and track their primary status.
  * Enhanced issued credentials record with organization association to improve data organization and management across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->