### PR TITLE
fix: used protocolversion 2 for indy flows

### DIFF
--- a/apps/api-gateway/src/dtos/credential-offer.dto.ts
+++ b/apps/api-gateway/src/dtos/credential-offer.dto.ts
@@ -7,7 +7,7 @@ interface attributeValue {
 }
 
 export class IssueCredentialOffer {
-  @ApiProperty({ example: { protocolVersion: 'v1' } })
+  @ApiProperty({ example: { protocolVersion: 'v2' } })
   @IsNotEmpty({ message: 'Please provide valid protocol-version' })
   @IsString({ message: 'protocol-version should be string' })
   protocolVersion: string;

--- a/apps/api-gateway/src/dtos/issue-credential.dto.ts
+++ b/apps/api-gateway/src/dtos/issue-credential.dto.ts
@@ -4,37 +4,35 @@ import { toLowerCase, trim } from '@credebl/common/cast.helper';
 import { Transform } from 'class-transformer';
 
 interface attribute {
-    name: string;
-    value: string;
+  name: string;
+  value: string;
 }
 
 export class IssueCredentialDto {
+  @ApiProperty({ example: 'v2' })
+  @Transform(({ value }) => trim(value))
+  @Transform(({ value }) => toLowerCase(value))
+  @IsNotEmpty({ message: 'Please provide valid protocolVersion' })
+  @IsString({ message: 'protocolVersion should be string' })
+  protocolVersion: string;
 
+  @ApiProperty({ example: [{ value: 'string', name: 'string' }] })
+  @IsNotEmpty({ message: 'Please provide valid attributes' })
+  @IsArray({ message: 'attributes should be array' })
+  attributes: attribute[];
 
-    @ApiProperty({ example: 'v1' })
-    @Transform(({ value }) => trim(value))
-    @Transform(({ value }) => toLowerCase(value))
-    @IsNotEmpty({ message: 'Please provide valid protocolVersion' })
-    @IsString({ message: 'protocolVersion should be string' })
-    protocolVersion: string;
+  @ApiProperty({ example: 'string' })
+  @IsNotEmpty({ message: 'Please provide valid credentialDefinitionId' })
+  @IsString({ message: 'credentialDefinitionId should be string' })
+  credentialDefinitionId: string;
 
-    @ApiProperty({ example: [{ 'value': 'string', 'name': 'string' }] })
-    @IsNotEmpty({ message: 'Please provide valid attributes' })
-    @IsArray({ message: 'attributes should be array' })
-    attributes: attribute[];
+  @ApiProperty({ example: 'string' })
+  @IsNotEmpty({ message: 'Please provide valid comment' })
+  @IsString({ message: 'comment should be string' })
+  comment: string;
 
-    @ApiProperty({ example: 'string' })
-    @IsNotEmpty({ message: 'Please provide valid credentialDefinitionId' })
-    @IsString({ message: 'credentialDefinitionId should be string' })
-    credentialDefinitionId: string;
-
-    @ApiProperty({ example: 'string' })
-    @IsNotEmpty({ message: 'Please provide valid comment' })
-    @IsString({ message: 'comment should be string' })
-    comment: string;
-
-    @ApiProperty({ example: '3fa85f64-5717-4562-b3fc-2c963f66afa6' })
-    @IsNotEmpty({ message: 'Please provide valid connectionId' })
-    @IsString({ message: 'connectionId should be string' })
-    connectionId: string;
+  @ApiProperty({ example: '3fa85f64-5717-4562-b3fc-2c963f66afa6' })
+  @IsNotEmpty({ message: 'Please provide valid connectionId' })
+  @IsString({ message: 'connectionId should be string' })
+  connectionId: string;
 }

--- a/apps/api-gateway/src/issuance/dtos/issuance.dto.ts
+++ b/apps/api-gateway/src/issuance/dtos/issuance.dto.ts
@@ -192,7 +192,7 @@ export class CredentialsIssuanceDto {
   @IsOptional()
   comment: string;
 
-  @ApiPropertyOptional({ example: 'v1' })
+  @ApiPropertyOptional({ example: 'v2' })
   @IsOptional()
   @IsNotEmpty({ message: 'Please provide valid protocol version' })
   @IsString({ message: 'protocol version should be string' })
@@ -467,7 +467,7 @@ export class OOBCredentialDtoWithEmail {
   @IsString({ message: 'comment should be string' })
   comment?: string;
 
-  @ApiProperty({ example: 'v1' })
+  @ApiProperty({ example: 'v2' })
   @IsOptional()
   @IsNotEmpty({ message: 'Please provide valid protocol version' })
   @IsString({ message: 'protocol version should be string' })

--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -202,7 +202,7 @@ export class IssuanceService {
 
         if (payload.credentialType === IssueCredentialType.INDY) {
           issueData = {
-            protocolVersion: payload.protocolVersion || 'v1',
+            protocolVersion: payload.protocolVersion || 'v2',
             connectionId,
             credentialFormats: {
               indy: {
@@ -392,7 +392,7 @@ export class IssuanceService {
       let issueData;
       if (credentialType === IssueCredentialType.INDY) {
         issueData = {
-          protocolVersion: protocolVersion || 'v1',
+          protocolVersion: protocolVersion || 'v2',
           credentialFormats: {
             indy: {
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -990,7 +990,7 @@ export class IssuanceService {
       this.logger.debug('This is an email issuance of type', credentialType);
       if (IssueCredentialType.INDY === credentialType) {
         outOfBandIssuancePayload = {
-          protocolVersion: protocolVersion || 'v1',
+          protocolVersion: protocolVersion || 'v2',
           credentialFormats: {
             indy: {
               // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/apps/verification/src/verification.service.ts
+++ b/apps/verification/src/verification.service.ts
@@ -303,7 +303,7 @@ export class VerificationService {
             requestProof as IRequestProof
           );
           payload.proofRequestPayload = {
-            protocolVersion: requestProof.protocolVersion || ProtocolVersionType.PROTOCOL_VERSION_1,
+            protocolVersion: requestProof.protocolVersion || ProtocolVersionType.PROTOCOL_VERSION_2,
             proofFormats: {
               indy: {
                 name: ProofRequestLabel.PROOF_REQUEST,
@@ -494,7 +494,7 @@ export class VerificationService {
       let payload: IProofRequestPayload;
 
       if (ProofRequestType.INDY === type) {
-        updateOutOfBandRequestProof.protocolVersion = updateOutOfBandRequestProof.protocolVersion || 'v1';
+        updateOutOfBandRequestProof.protocolVersion = updateOutOfBandRequestProof.protocolVersion || 'v2';
         updateOutOfBandRequestProof.invitationDid = invitationDid || undefined;
         updateOutOfBandRequestProof.imageUrl = getOrganization?.logoUrl || undefined;
         payload = {


### PR DESCRIPTION
#What?
- Using protocolVersion V2 by default for Indy issuance and verification

#Why?
- Mobile wallet has already migrated to protocol version v2 and it was breaking the flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * API documentation examples updated to reflect protocol version v2.

* **Updates**
  * Credential issuance now defaults to protocol version v2 (previously v1).
  * Proof verification now defaults to protocol version v2 (previously v1).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/credebl/platform/pull/1664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->