### PR TITLE
fix(geo-data): correct country_id mismatch in states.csv and cities.csv

### DIFF
--- a/libs/prisma-service/prisma/seed.ts
+++ b/libs/prisma-service/prisma/seed.ts
@@ -187,6 +187,9 @@ const createPlatformUser = async (): Promise<void> => {
 
       logger.log(platformUser);
     } else {
+      // User already exists — still need to set platformUserId so downstream
+      // functions (createPlatformOrganization) have a valid UUID for createdBy/lastChangedBy
+      platformUserId = existPlatformAdminUser[0].id;
       logger.log('Already seeding in user');
     }
   } catch (error) {


### PR DESCRIPTION
### Problem

`states.csv` contains a systematic `country_id` corruption affecting all countries from Germany onward (~148 countries). The `country_code` column is correct, but `country_id` values don't match the IDs in `countries.csv` — causing states of one country to be served under another.

**Example:**
| File | name | country_id (before) | country_code | Actual country |
|------|------|----------------------|--------------|----------------|
| states.csv | Andhra Pradesh | 99 | IN | Hong Kong (99) ≠ India (102) |

This means selecting **India** in the UI returned **Iran's states**. Selecting **Hong Kong** returned **India's states**. No error is thrown — the data is silently wrong.

`cities.csv` had the same downstream corruption.

### Root Cause

The `country_id` column was not derived from `countries.csv` IDs. The `country_code` column was always correct, but `country_id` diverged for ~148 countries starting alphabetically around Germany.

### Fix

Regenerated `country_id` in both CSVs by mapping `country_code` (ISO) → correct `id` from `countries.csv`.

- `states.csv` — 4,581 rows corrected
- `cities.csv` — 105,446 rows corrected

### Impact

| Scenario | Impact |
|----------|--------|
| Fresh local setup / CI | ✅ Fixed — correct geo data on first seed |
| Existing seeded deployment | ✅ No impact — import script skips non-empty tables |

### Testing

```sql
-- Verify India's states return correctly
SELECT * FROM states WHERE country_id = 102 LIMIT 5;
-- All rows should have country_code = 'IN'
```
### Note
Supersedes #1681 — this PR isolates only the geo-data fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the initial setup flow so an existing platform admin account is correctly reused during seeding.
  * Prevented missing user references from affecting organization records created afterward, helping keep audit fields accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->