### PR TITLE
fix: search functionality in org/public-profile api

### DIFF
--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -67,6 +67,7 @@ import * as jwt from 'jsonwebtoken';
 import { ClientTokenDto } from '../dtos/client-token.dto';
 import { EmailService } from '@credebl/common/email.service';
 import { uuidRegex } from '@credebl/common/common.constant';
+import { isUUID } from 'class-validator';
 
 @Injectable()
 export class OrganizationService {
@@ -771,7 +772,8 @@ export class OrganizationService {
         publicProfile: true,
         OR: [
           { name: { contains: search, mode: 'insensitive' } },
-          { description: { contains: search, mode: 'insensitive' } }
+          { description: { contains: search, mode: 'insensitive' } },
+          ...(isUUID(search) ? [{ id: { equals: search } }] : [])
         ]
       };
 

--- a/libs/enum/src/enum.ts
+++ b/libs/enum/src/enum.ts
@@ -373,7 +373,8 @@ export enum X509ExtendedKeyUsage {
 export enum CredentialFormat {
   SdJwtVc = 'dc+sd-jwt',
   Mdoc = 'mso_mdoc',
-  JwtVcJsonLd = 'jwt_vc_json-ld'
+  JwtVcJsonLd = 'jwt_vc_json-ld',
+  LdpVc = 'ldp_vc'
 }
 
 export enum AttributeType {


### PR DESCRIPTION
# What 

- fix search by id for org/public-profile api 
- works with both name and id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization search now supports exact matches by ID when a UUID is entered, in addition to name and description matching.
  * Added support for the `ldp_vc` credential format alongside existing formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->