### PR TITLE
Fix: successful response for empty attributes when creating shortening URLs

### DIFF
--- a/apps/api-gateway/src/utilities/dtos/shortening-url.dto.spec.ts
+++ b/apps/api-gateway/src/utilities/dtos/shortening-url.dto.spec.ts
@@ -1,0 +1,31 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UtilitiesDto } from './shortening-url.dto';
+
+describe('UtilitiesDto', () => {
+  const basePayload = {
+    credentialId: 'cred-id',
+    schemaId: 'schema-id',
+    credDefId: 'cred-def-id',
+    invitationUrl: 'https://example.com/invite'
+  };
+
+  it('should pass validation when attributes contains at least one item', async () => {
+    const dto = plainToInstance(UtilitiesDto, {
+      ...basePayload,
+      attributes: [{ name: 'name', value: 'value' }]
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  it('should fail validation when attributes is an empty array', async () => {
+    const dto = plainToInstance(UtilitiesDto, {
+      ...basePayload,
+      attributes: []
+    });
+    const errors = await validate(dto);
+    const attributesError = errors.find((error) => 'attributes' === error.property);
+    expect(attributesError?.constraints?.arrayNotEmpty).toBe('attributes should not be empty');
+  });
+});

--- a/apps/api-gateway/src/utilities/dtos/shortening-url.dto.spec.ts
+++ b/apps/api-gateway/src/utilities/dtos/shortening-url.dto.spec.ts
@@ -28,4 +28,26 @@ describe('UtilitiesDto', () => {
     const attributesError = errors.find((error) => 'attributes' === error.property);
     expect(attributesError?.constraints?.arrayNotEmpty).toBe('attributes should not be empty');
   });
+
+  it('should fail validation when an attribute item is missing required fields', async () => {
+    const dto = plainToInstance(UtilitiesDto, {
+      ...basePayload,
+      attributes: [{}]
+    });
+    const errors = await validate(dto);
+    const attributesError = errors.find((error) => 'attributes' === error.property);
+    expect(attributesError?.children?.length).toBeGreaterThan(0);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('should fail validation when an attribute name is not a string', async () => {
+    const dto = plainToInstance(UtilitiesDto, {
+      ...basePayload,
+      attributes: [{ name: 123, value: 'value' }]
+    });
+    const errors = await validate(dto);
+    const attributesError = errors.find((error) => 'attributes' === error.property);
+    const nameError = attributesError?.children?.[0]?.children?.find((error) => 'name' === error.property);
+    expect(nameError?.constraints?.isString).toBeDefined();
+  });
 });

--- a/apps/api-gateway/src/utilities/dtos/shortening-url.dto.ts
+++ b/apps/api-gateway/src/utilities/dtos/shortening-url.dto.ts
@@ -1,5 +1,18 @@
 import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
-import { ArrayNotEmpty, IsArray, IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ArrayNotEmpty, IsArray, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
+
+export class Attribute {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  value: string;
+}
 
 @ApiExtraModels()
 export class UtilitiesDto {
@@ -29,13 +42,10 @@ export class UtilitiesDto {
   })
   @IsArray({ message: 'attributes must be a valid array' })
   @ArrayNotEmpty({ message: 'attributes should not be empty' })
+  @ValidateNested({ each: true })
+  @Type(() => Attribute)
   @IsNotEmpty({ message: 'please provide valid attributes' })
   attributes: Attribute[];
-}
-
-interface Attribute {
-  name: string;
-  value: string;
 }
 
 export class StoreObjectDto {

--- a/apps/api-gateway/src/utilities/dtos/shortening-url.dto.ts
+++ b/apps/api-gateway/src/utilities/dtos/shortening-url.dto.ts
@@ -1,46 +1,44 @@
-
 import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsNotEmpty } from 'class-validator';
+import { ArrayNotEmpty, IsArray, IsNotEmpty } from 'class-validator';
 
 @ApiExtraModels()
-  
 export class UtilitiesDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  credentialId: string;
 
-    @ApiProperty()
-    @IsNotEmpty()
-    credentialId: string;
+  @ApiProperty()
+  @IsNotEmpty()
+  schemaId: string;
 
-    @ApiProperty()
-    @IsNotEmpty()
-    schemaId: string;
+  @ApiProperty()
+  @IsNotEmpty()
+  credDefId: string;
 
-    @ApiProperty()
-    @IsNotEmpty()
-    credDefId: string; 
+  @ApiProperty()
+  @IsNotEmpty()
+  invitationUrl: string;
 
-    @ApiProperty()
-    @IsNotEmpty()
-    invitationUrl: string;
-
-    @ApiProperty({
-        example: [
-          {
-            name: 'name',
-            value: 'value'
-          }
-        ]
-      })
-      @IsArray({ message: 'attributes must be a valid array' })
-      @IsNotEmpty({ message: 'please provide valid attributes' })
-      attributes: Attribute[];
+  @ApiProperty({
+    example: [
+      {
+        name: 'name',
+        value: 'value'
+      }
+    ]
+  })
+  @IsArray({ message: 'attributes must be a valid array' })
+  @ArrayNotEmpty({ message: 'attributes should not be empty' })
+  @IsNotEmpty({ message: 'please provide valid attributes' })
+  attributes: Attribute[];
 }
 
 interface Attribute {
-    name: string;
-    value: string;
-  }
+  name: string;
+  value: string;
+}
 
-  export class StoreObjectDto {
+export class StoreObjectDto {
   @ApiProperty()
   @IsNotEmpty()
   data: string | object;


### PR DESCRIPTION
# Fix successful response for empty `attributes` when creating shortening URLs

## Summary

This PR fixes the validation for the `POST /v1/utilities` endpoint when creating a shortening URL.

Previously, requests with an empty `attributes` array (`[]`) were accepted and returned a `201 Created` response. This behavior was incorrect because a shortening URL cannot be created without any attributes.

The endpoint now returns a **400 Bad Request** with the appropriate validation message when `attributes` is an empty array.

## Changes

* Added validation to reject empty `attributes` arrays.
* Preserved the existing behavior for valid requests.
* Added tests to cover the validation.

## Before

**Request**

```json
{
  "attributes": []
}
```

**Response**

```json
HTTP 201 Created
{
  "statusCode": 201,
  "message": "Shortening Url created successfully"
}
```

## After

**Request**

```json
{
  "attributes": []
}
```

**Response**

```json
HTTP 400 Bad Request
{
  "statusCode": 400,
  "message": "attributes should not be empty",
  "error": "Bad Request"
}
```

## Testing
To run tests for specific error, use this command: pnpm test -- shortening-url.dto.spec.ts

* ✅ Valid request with non-empty `attributes` returns `201 Created`.
* ✅ Request with `attributes: []` returns `400 Bad Request`.
* ✅ Existing functionality remains unchanged.
* ✅ Malformed item like [{}] or [{ name: 123 }] will not pass, extended API correction

Fixes #1219.

<img width="675" height="312" alt="Screenshot 2026-07-07 at 3 54 37 PM" src="https://github.com/user-attachments/assets/6251d71a-cf16-4915-8437-3a627d206389" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for URL utility input so empty attribute lists are rejected with a clear message.
  * Improved consistency of request data validation and example formatting.

* **Tests**
  * Added test coverage for valid and invalid validation cases to confirm the expected error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->