### PR TITLE
fix(security): harden auth and status-list allocation

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -176,6 +176,7 @@ KEYCLOAK_MANAGEMENT_CLIENT_ID=credeblClient
 KEYCLOAK_MANAGEMENT_CLIENT_SECRET=
 KEYCLOAK_REALM=credebl-platform
 # Optional comma-separated allowlist. When omitted, the issuer is derived from KEYCLOAK_DOMAIN and KEYCLOAK_REALM.
+# The API gateway fails closed unless this is set or both KEYCLOAK_DOMAIN and KEYCLOAK_REALM are configured.
 JWT_TRUSTED_ISSUERS=http://localhost:8080/realms/credebl-platform
 
 # Provide schema server URL and token 

--- a/.env.demo
+++ b/.env.demo
@@ -175,6 +175,8 @@ KEYCLOAK_MASTER_REALM=master
 KEYCLOAK_MANAGEMENT_CLIENT_ID=credeblClient
 KEYCLOAK_MANAGEMENT_CLIENT_SECRET=
 KEYCLOAK_REALM=credebl-platform
+# Optional comma-separated allowlist. When omitted, the issuer is derived from KEYCLOAK_DOMAIN and KEYCLOAK_REALM.
+JWT_TRUSTED_ISSUERS=http://localhost:8080/realms/credebl-platform
 
 # Provide schema server URL and token 
 SCHEMA_FILE_SERVER_URL=

--- a/.env.demo
+++ b/.env.demo
@@ -395,8 +395,8 @@ SECRETS_PROVIDER=openbao
 BAO_URL=http://127.0.0.1:8200
 # Default KV v2 path fetched at boot and injected into process.env
 BAO_SECRET_PATH=secret/data/credebl_resend_api_key
-# AppRole credentials. Generate your own via: ./openbao-init.sh
-# (values below are for the local 'openbao' container created by docker-compose.openbao.yml)
-BAO_ROLE_ID=ca2a350b-1871-0851-8557-42b36aa9c623
-BAO_SECRET_ID=3f0d8d45-c232-f5c1-2984-fe58e5144be8
+# AppRole credentials. Provision your own outside version control via: ./openbao-init.sh
+# The values below are non-functional placeholders; never commit real role/secret IDs.
+BAO_ROLE_ID=00000000-0000-0000-0000-000000000000
+BAO_SECRET_ID=00000000-0000-0000-0000-000000000000
 HIDE_EXPERIMENTAL_OIDC_CONTROLLERS=false

--- a/apps/api-gateway/src/authz/jwt-issuer.util.spec.ts
+++ b/apps/api-gateway/src/authz/jwt-issuer.util.spec.ts
@@ -28,4 +28,13 @@ describe('trusted JWT issuers', () => {
   it('fails closed when no trusted issuer configuration exists', () => {
     expect(() => getTrustedJwtIssuers({})).toThrow('JWT_TRUSTED_ISSUERS');
   });
+
+  it('allows HTTP only for explicit loopback issuers', () => {
+    expect(getTrustedJwtIssuers({ JWT_TRUSTED_ISSUERS: 'http://localhost:8080/realms/platform' })).toEqual([
+      'http://localhost:8080/realms/platform'
+    ]);
+    expect(() => getTrustedJwtIssuers({ JWT_TRUSTED_ISSUERS: 'http://identity.example/realms/platform' })).toThrow(
+      'Invalid trusted JWT issuer'
+    );
+  });
 });

--- a/apps/api-gateway/src/authz/jwt-issuer.util.spec.ts
+++ b/apps/api-gateway/src/authz/jwt-issuer.util.spec.ts
@@ -2,9 +2,8 @@ import { getTrustedJwksUri, getTrustedJwtIssuers } from './jwt-issuer.util';
 
 describe('trusted JWT issuers', () => {
   it('derives the Keycloak realm issuer when an explicit allowlist is not configured', () => {
-    expect(getTrustedJwtIssuers({ KEYCLOAK_DOMAIN: 'https://identity.example/', KEYCLOAK_REALM: 'platform' })).toEqual([
-      'https://identity.example/realms/platform'
-    ]);
+    const env = { KEYCLOAK_DOMAIN: 'https://identity.example/', KEYCLOAK_REALM: 'platform' };
+    expect(getTrustedJwtIssuers(env)).toEqual(['https://identity.example/realms/platform']);
   });
 
   it('supports an explicit issuer allowlist and removes duplicates', () => {
@@ -17,12 +16,13 @@ describe('trusted JWT issuers', () => {
   });
 
   it('builds a JWKS URI only for an allowlisted issuer', () => {
-    expect(
-      getTrustedJwksUri('https://identity.example/realms/platform', ['https://identity.example/realms/platform'])
-    ).toBe('https://identity.example/realms/platform/protocol/openid-connect/certs');
-    expect(() =>
-      getTrustedJwksUri('https://attacker.example/realms/platform', ['https://identity.example/realms/platform'])
-    ).toThrow('JWT issuer is not trusted');
+    const issuer = 'https://identity.example/realms/platform';
+    const attackerIssuer = 'https://attacker.example/realms/platform';
+    const trustedIssuers = [issuer];
+    expect(getTrustedJwksUri(issuer, trustedIssuers)).toBe(
+      'https://identity.example/realms/platform/protocol/openid-connect/certs'
+    );
+    expect(() => getTrustedJwksUri(attackerIssuer, trustedIssuers)).toThrow('JWT issuer is not trusted');
   });
 
   it('fails closed when no trusted issuer configuration exists', () => {
@@ -30,9 +30,8 @@ describe('trusted JWT issuers', () => {
   });
 
   it('allows HTTP only for explicit loopback issuers', () => {
-    expect(getTrustedJwtIssuers({ JWT_TRUSTED_ISSUERS: 'http://localhost:8080/realms/platform' })).toEqual([
-      'http://localhost:8080/realms/platform'
-    ]);
+    const loopbackEnv = { JWT_TRUSTED_ISSUERS: 'http://localhost:8080/realms/platform' };
+    expect(getTrustedJwtIssuers(loopbackEnv)).toEqual(['http://localhost:8080/realms/platform']);
     expect(() => getTrustedJwtIssuers({ JWT_TRUSTED_ISSUERS: 'http://identity.example/realms/platform' })).toThrow(
       'Invalid trusted JWT issuer'
     );

--- a/apps/api-gateway/src/authz/jwt-issuer.util.spec.ts
+++ b/apps/api-gateway/src/authz/jwt-issuer.util.spec.ts
@@ -1,0 +1,31 @@
+import { getTrustedJwksUri, getTrustedJwtIssuers } from './jwt-issuer.util';
+
+describe('trusted JWT issuers', () => {
+  it('derives the Keycloak realm issuer when an explicit allowlist is not configured', () => {
+    expect(getTrustedJwtIssuers({ KEYCLOAK_DOMAIN: 'https://identity.example/', KEYCLOAK_REALM: 'platform' })).toEqual([
+      'https://identity.example/realms/platform'
+    ]);
+  });
+
+  it('supports an explicit issuer allowlist and removes duplicates', () => {
+    expect(
+      getTrustedJwtIssuers({
+        JWT_TRUSTED_ISSUERS:
+          'https://id-a.example/realms/a, https://id-b.example/realms/b/,https://id-a.example/realms/a'
+      })
+    ).toEqual(['https://id-a.example/realms/a', 'https://id-b.example/realms/b']);
+  });
+
+  it('builds a JWKS URI only for an allowlisted issuer', () => {
+    expect(
+      getTrustedJwksUri('https://identity.example/realms/platform', ['https://identity.example/realms/platform'])
+    ).toBe('https://identity.example/realms/platform/protocol/openid-connect/certs');
+    expect(() =>
+      getTrustedJwksUri('https://attacker.example/realms/platform', ['https://identity.example/realms/platform'])
+    ).toThrow('JWT issuer is not trusted');
+  });
+
+  it('fails closed when no trusted issuer configuration exists', () => {
+    expect(() => getTrustedJwtIssuers({})).toThrow('JWT_TRUSTED_ISSUERS');
+  });
+});

--- a/apps/api-gateway/src/authz/jwt-issuer.util.ts
+++ b/apps/api-gateway/src/authz/jwt-issuer.util.ts
@@ -38,9 +38,7 @@ export const getTrustedJwtIssuers = (env: NodeJS.ProcessEnv = process.env): stri
   return [...new Set(issuers.map(validateIssuer))];
 };
 
-export const getTrustedJwtIssuerVariants = (trustedIssuers: string[]): string[] => [
-  ...new Set(trustedIssuers.flatMap((issuer) => [issuer, `${issuer}/`]))
-];
+export const getTrustedJwtIssuerVariants = (trustedIssuers: string[]): string[] => [...new Set(trustedIssuers.flatMap((issuer) => [issuer, `${issuer}/`]))];
 
 export const getTrustedJwksUri = (issuer: unknown, trustedIssuers: string[]): string => {
   if ('string' !== typeof issuer) {

--- a/apps/api-gateway/src/authz/jwt-issuer.util.ts
+++ b/apps/api-gateway/src/authz/jwt-issuer.util.ts
@@ -1,6 +1,13 @@
 import { CommonConstants } from '@credebl/common/common.constant';
 
-const trimTrailingSlashes = (value: string): string => value.trim().replace(/\/+$/, '');
+const trimTrailingSlashes = (value: string): string => {
+  const trimmedValue = value.trim();
+  let endIndex = trimmedValue.length;
+  while (0 < endIndex && '/' === trimmedValue.charAt(endIndex - 1)) {
+    endIndex -= 1;
+  }
+  return trimmedValue.slice(0, endIndex);
+};
 
 const validateIssuer = (value: string): string => {
   const issuer = trimTrailingSlashes(value);
@@ -25,11 +32,10 @@ export const getTrustedJwtIssuers = (env: NodeJS.ProcessEnv = process.env): stri
     .map((issuer) => issuer.trim())
     .filter(Boolean);
 
-  const issuers = configuredIssuers?.length
-    ? configuredIssuers
-    : env.KEYCLOAK_DOMAIN && env.KEYCLOAK_REALM
-      ? [`${trimTrailingSlashes(env.KEYCLOAK_DOMAIN)}/realms/${env.KEYCLOAK_REALM.trim()}`]
-      : [];
+  let issuers = [...(configuredIssuers ?? [])];
+  if (0 === issuers.length && env.KEYCLOAK_DOMAIN && env.KEYCLOAK_REALM) {
+    issuers = [`${trimTrailingSlashes(env.KEYCLOAK_DOMAIN)}/realms/${env.KEYCLOAK_REALM.trim()}`];
+  }
 
   if (0 === issuers.length) {
     throw new Error('JWT_TRUSTED_ISSUERS or both KEYCLOAK_DOMAIN and KEYCLOAK_REALM must be configured');
@@ -38,11 +44,13 @@ export const getTrustedJwtIssuers = (env: NodeJS.ProcessEnv = process.env): stri
   return [...new Set(issuers.map(validateIssuer))];
 };
 
-export const getTrustedJwtIssuerVariants = (trustedIssuers: string[]): string[] => [...new Set(trustedIssuers.flatMap((issuer) => [issuer, `${issuer}/`]))];
+export const getTrustedJwtIssuerVariants = (trustedIssuers: string[]): string[] => [
+  ...new Set(trustedIssuers.flatMap((issuer) => [issuer, `${issuer}/`]))
+];
 
 export const getTrustedJwksUri = (issuer: unknown, trustedIssuers: string[]): string => {
   if ('string' !== typeof issuer) {
-    throw new Error('JWT issuer is missing');
+    throw new TypeError('JWT issuer is missing');
   }
 
   const normalizedIssuer = trimTrailingSlashes(issuer);

--- a/apps/api-gateway/src/authz/jwt-issuer.util.ts
+++ b/apps/api-gateway/src/authz/jwt-issuer.util.ts
@@ -4,7 +4,12 @@ const trimTrailingSlashes = (value: string): string => value.trim().replace(/\/+
 
 const validateIssuer = (value: string): string => {
   const issuer = trimTrailingSlashes(value);
-  const parsed = new URL(issuer);
+  let parsed: URL;
+  try {
+    parsed = new URL(issuer);
+  } catch {
+    throw new Error(`Invalid trusted JWT issuer: ${value}`);
+  }
   const isLoopbackHost = ['localhost', '127.0.0.1', '[::1]', '::1'].includes(parsed.hostname.toLowerCase());
   const usesAllowedProtocol = 'https:' === parsed.protocol || ('http:' === parsed.protocol && isLoopbackHost);
 
@@ -32,6 +37,10 @@ export const getTrustedJwtIssuers = (env: NodeJS.ProcessEnv = process.env): stri
 
   return [...new Set(issuers.map(validateIssuer))];
 };
+
+export const getTrustedJwtIssuerVariants = (trustedIssuers: string[]): string[] => [
+  ...new Set(trustedIssuers.flatMap((issuer) => [issuer, `${issuer}/`]))
+];
 
 export const getTrustedJwksUri = (issuer: unknown, trustedIssuers: string[]): string => {
   if ('string' !== typeof issuer) {

--- a/apps/api-gateway/src/authz/jwt-issuer.util.ts
+++ b/apps/api-gateway/src/authz/jwt-issuer.util.ts
@@ -1,0 +1,51 @@
+import { CommonConstants } from '@credebl/common/common.constant';
+
+const trimTrailingSlashes = (value: string): string => value.trim().replace(/\/+$/, '');
+
+const validateIssuer = (value: string): string => {
+  const issuer = trimTrailingSlashes(value);
+  const parsed = new URL(issuer);
+
+  if (
+    !['http:', 'https:'].includes(parsed.protocol) ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error(`Invalid trusted JWT issuer: ${value}`);
+  }
+
+  return issuer;
+};
+
+export const getTrustedJwtIssuers = (env: NodeJS.ProcessEnv = process.env): string[] => {
+  const configuredIssuers = env.JWT_TRUSTED_ISSUERS?.split(',')
+    .map((issuer) => issuer.trim())
+    .filter(Boolean);
+
+  const issuers = configuredIssuers?.length
+    ? configuredIssuers
+    : env.KEYCLOAK_DOMAIN && env.KEYCLOAK_REALM
+      ? [`${trimTrailingSlashes(env.KEYCLOAK_DOMAIN)}/realms/${env.KEYCLOAK_REALM.trim()}`]
+      : [];
+
+  if (0 === issuers.length) {
+    throw new Error('JWT_TRUSTED_ISSUERS or both KEYCLOAK_DOMAIN and KEYCLOAK_REALM must be configured');
+  }
+
+  return [...new Set(issuers.map(validateIssuer))];
+};
+
+export const getTrustedJwksUri = (issuer: unknown, trustedIssuers: string[]): string => {
+  if ('string' !== typeof issuer) {
+    throw new Error('JWT issuer is missing');
+  }
+
+  const normalizedIssuer = trimTrailingSlashes(issuer);
+  if (!trustedIssuers.includes(normalizedIssuer)) {
+    throw new Error('JWT issuer is not trusted');
+  }
+
+  return `${normalizedIssuer}${CommonConstants.URL_KEYCLOAK_JWKS}`;
+};

--- a/apps/api-gateway/src/authz/jwt-issuer.util.ts
+++ b/apps/api-gateway/src/authz/jwt-issuer.util.ts
@@ -5,14 +5,10 @@ const trimTrailingSlashes = (value: string): string => value.trim().replace(/\/+
 const validateIssuer = (value: string): string => {
   const issuer = trimTrailingSlashes(value);
   const parsed = new URL(issuer);
+  const isLoopbackHost = ['localhost', '127.0.0.1', '[::1]', '::1'].includes(parsed.hostname.toLowerCase());
+  const usesAllowedProtocol = 'https:' === parsed.protocol || ('http:' === parsed.protocol && isLoopbackHost);
 
-  if (
-    !['http:', 'https:'].includes(parsed.protocol) ||
-    parsed.username ||
-    parsed.password ||
-    parsed.search ||
-    parsed.hash
-  ) {
+  if (!usesAllowedProtocol || parsed.username || parsed.password || parsed.search || parsed.hash) {
     throw new Error(`Invalid trusted JWT issuer: ${value}`);
   }
 

--- a/apps/api-gateway/src/authz/jwt.strategy.ts
+++ b/apps/api-gateway/src/authz/jwt.strategy.ts
@@ -2,7 +2,7 @@
 import * as dotenv from 'dotenv';
 import * as jwt from 'jsonwebtoken';
 
-import { CommonConstants, uuidRegex } from '@credebl/common/common.constant';
+import { uuidRegex } from '@credebl/common/common.constant';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Injectable, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
 
@@ -14,6 +14,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ResponseMessages } from '@credebl/common/response-messages';
 import { UserService } from '../user/user.service';
 import { passportJwtSecret } from 'jwks-rsa';
+import { getTrustedJwksUri, getTrustedJwtIssuers } from './jwt-issuer.util';
 
 dotenv.config();
 
@@ -26,6 +27,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     private readonly organizationService: OrganizationService,
     private readonly authzService: AuthzService
   ) {
+    const trustedIssuers = getTrustedJwtIssuers();
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKeyProvider: async (request, jwtToken, done) => {
@@ -36,21 +38,21 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
           return done(new UnauthorizedException(ResponseMessages.user.error.invalidAccessToken), null);
         }
 
-        const audiance = decodedToken.iss.toString();
-        const jwtOptions = {
-          cache: true,
-          rateLimit: true,
-          jwksRequestsPerMinute: 5,
-          jwksUri: `${audiance}${CommonConstants.URL_KEYCLOAK_JWKS}`
-        };
-        const secretprovider = passportJwtSecret(jwtOptions);
-        let certkey;
-        secretprovider(request, jwtToken, async (err, data) => {
-          certkey = data;
-          done(null, certkey);
-        });
+        try {
+          const jwtOptions = {
+            cache: true,
+            rateLimit: true,
+            jwksRequestsPerMinute: 5,
+            jwksUri: getTrustedJwksUri(decodedToken.iss, trustedIssuers)
+          };
+          const secretprovider = passportJwtSecret(jwtOptions);
+          secretprovider(request, jwtToken, (err, data) => done(err, data));
+        } catch (error) {
+          return done(new UnauthorizedException(ResponseMessages.user.error.invalidAccessToken), null);
+        }
       },
-      algorithms: ['RS256']
+      algorithms: ['RS256'],
+      issuer: trustedIssuers
     });
   }
 

--- a/apps/api-gateway/src/authz/jwt.strategy.ts
+++ b/apps/api-gateway/src/authz/jwt.strategy.ts
@@ -14,7 +14,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ResponseMessages } from '@credebl/common/response-messages';
 import { UserService } from '../user/user.service';
 import { passportJwtSecret } from 'jwks-rsa';
-import { getTrustedJwksUri, getTrustedJwtIssuers } from './jwt-issuer.util';
+import { getTrustedJwksUri, getTrustedJwtIssuerVariants, getTrustedJwtIssuers } from './jwt-issuer.util';
 
 dotenv.config();
 
@@ -28,6 +28,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     private readonly authzService: AuthzService
   ) {
     const trustedIssuers = getTrustedJwtIssuers();
+    const trustedIssuerVariants = getTrustedJwtIssuerVariants(trustedIssuers);
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKeyProvider: async (request, jwtToken, done) => {
@@ -52,7 +53,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         }
       },
       algorithms: ['RS256'],
-      issuer: trustedIssuers
+      issuer: trustedIssuerVariants
     });
   }
 

--- a/apps/api-gateway/src/authz/jwt.strategy.ts
+++ b/apps/api-gateway/src/authz/jwt.strategy.ts
@@ -49,6 +49,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
           const secretprovider = passportJwtSecret(jwtOptions);
           secretprovider(request, jwtToken, (err, data) => done(err, data));
         } catch (error) {
+          this.logger.error(`Error resolving JWKS secret:::${error}`);
           return done(new UnauthorizedException(ResponseMessages.user.error.invalidAccessToken), null);
         }
       },

--- a/apps/api-gateway/src/authz/mobile-jwt.strategy.ts
+++ b/apps/api-gateway/src/authz/mobile-jwt.strategy.ts
@@ -2,7 +2,7 @@ import * as dotenv from 'dotenv';
 import * as jwt from 'jsonwebtoken';
 
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 
 import { PassportStrategy } from '@nestjs/passport';
 import { passportJwtSecret } from 'jwks-rsa';
@@ -17,6 +17,8 @@ interface MobileJwtPayload {
 
 @Injectable()
 export class MobileJwtStrategy extends PassportStrategy(Strategy, 'mobile-jwt') {
+  private readonly logger = new Logger('MobileJwt Strategy');
+
   constructor() {
     const trustedIssuers = getTrustedJwtIssuers();
     const trustedIssuerVariants = getTrustedJwtIssuerVariants(trustedIssuers);
@@ -34,6 +36,7 @@ export class MobileJwtStrategy extends PassportStrategy(Strategy, 'mobile-jwt') 
           const secretprovider = passportJwtSecret(jwtOptions);
           secretprovider(request, jwtToken, (err, data) => done(err, data));
         } catch (error) {
+          this.logger.error(`Error resolving JWKS secret:::${error}`);
           return done(new UnauthorizedException('Authorization header contains an invalid token'), null);
         }
       },

--- a/apps/api-gateway/src/authz/mobile-jwt.strategy.ts
+++ b/apps/api-gateway/src/authz/mobile-jwt.strategy.ts
@@ -2,50 +2,51 @@ import * as dotenv from 'dotenv';
 import * as jwt from 'jsonwebtoken';
 
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { BadRequestException, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 
-import { CommonConstants } from '@credebl/common/common.constant';
 import { PassportStrategy } from '@nestjs/passport';
 import { passportJwtSecret } from 'jwks-rsa';
+import { getTrustedJwksUri, getTrustedJwtIssuers } from './jwt-issuer.util';
 dotenv.config();
-const logger = new Logger();
+
+interface MobileJwtPayload {
+  azp?: string;
+  iss?: string;
+  [key: string]: unknown;
+}
 
 @Injectable()
 export class MobileJwtStrategy extends PassportStrategy(Strategy, 'mobile-jwt') {
-  private readonly logger = new Logger();
-
   constructor() {
+    const trustedIssuers = getTrustedJwtIssuers();
     super({
-
       secretOrKeyProvider: (request, jwtToken, done) => {
-        const decodedToken: any = jwt.decode(jwtToken);       
-        const audiance = decodedToken.iss.toString();      
-        const jwtOptions = {
-          cache: true,
-          rateLimit: true,
-          jwksRequestsPerMinute: 5,
-          jwksUri: `${audiance}${CommonConstants.URL_KEYCLOAK_JWKS}`
-        };
-        const secretprovider = passportJwtSecret(jwtOptions);
-        let certkey;
-        secretprovider(request, jwtToken, async (err, data) => {         
-          certkey = data;
-          done(null, certkey);
-        });
+        const decodedToken = jwt.decode(jwtToken);
+        const issuer = decodedToken && 'object' === typeof decodedToken ? decodedToken.iss : undefined;
+        try {
+          const jwtOptions = {
+            cache: true,
+            rateLimit: true,
+            jwksRequestsPerMinute: 5,
+            jwksUri: getTrustedJwksUri(issuer, trustedIssuers)
+          };
+          const secretprovider = passportJwtSecret(jwtOptions);
+          secretprovider(request, jwtToken, (err, data) => done(err, data));
+        } catch (error) {
+          return done(new UnauthorizedException('Authorization header contains an invalid token'), null);
+        }
       },
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      algorithms: ['RS256']
+      algorithms: ['RS256'],
+      issuer: trustedIssuers
     });
   }
 
-  validate(payload: any) {
+  validate(payload: MobileJwtPayload): MobileJwtPayload {
     if ('adeyaClient' !== payload.azp) {
-      throw new UnauthorizedException(
-        'Authorization header contains an invalid token'
-      );
+      throw new UnauthorizedException('Authorization header contains an invalid token');
     } else {
       return payload;
     }
-    
   }
 }

--- a/apps/api-gateway/src/authz/mobile-jwt.strategy.ts
+++ b/apps/api-gateway/src/authz/mobile-jwt.strategy.ts
@@ -6,7 +6,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 
 import { PassportStrategy } from '@nestjs/passport';
 import { passportJwtSecret } from 'jwks-rsa';
-import { getTrustedJwksUri, getTrustedJwtIssuers } from './jwt-issuer.util';
+import { getTrustedJwksUri, getTrustedJwtIssuerVariants, getTrustedJwtIssuers } from './jwt-issuer.util';
 dotenv.config();
 
 interface MobileJwtPayload {
@@ -19,6 +19,7 @@ interface MobileJwtPayload {
 export class MobileJwtStrategy extends PassportStrategy(Strategy, 'mobile-jwt') {
   constructor() {
     const trustedIssuers = getTrustedJwtIssuers();
+    const trustedIssuerVariants = getTrustedJwtIssuerVariants(trustedIssuers);
     super({
       secretOrKeyProvider: (request, jwtToken, done) => {
         const decodedToken = jwt.decode(jwtToken);
@@ -38,7 +39,7 @@ export class MobileJwtStrategy extends PassportStrategy(Strategy, 'mobile-jwt') 
       },
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       algorithms: ['RS256'],
-      issuer: trustedIssuers
+      issuer: trustedIssuerVariants
     });
   }
 

--- a/apps/api-gateway/src/fido/fido.controller.spec.ts
+++ b/apps/api-gateway/src/fido/fido.controller.spec.ts
@@ -14,6 +14,9 @@ const response = (): { status: jest.Mock; json: jest.Mock } => {
 describe('FidoController passkey management authorization', () => {
   const fidoService = {
     fetchFidoUserDetails: jest.fn(),
+    generateRegistrationOption: jest.fn(),
+    verifyRegistration: jest.fn(),
+    updateFidoUser: jest.fn(),
     updateFidoUserDeviceName: jest.fn(),
     deleteFidoUserDevice: jest.fn()
   };
@@ -51,5 +54,28 @@ describe('FidoController passkey management authorization', () => {
       response() as never
     );
     expect(fidoService.deleteFidoUserDevice).toHaveBeenCalledWith('credential-id', 'owner@example.com');
+  });
+
+  it('rejects registration for another user', async () => {
+    await expect(
+      controller.generateRegistrationOption(
+        { user: { email: 'owner@example.com' } },
+        { deviceFlag: false },
+        'other@example.com',
+        response() as never
+      )
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(fidoService.generateRegistrationOption).not.toHaveBeenCalled();
+  });
+
+  it('passes the authenticated identity to passkey detail updates', async () => {
+    fidoService.updateFidoUser.mockResolvedValue({ response: 'updated' });
+    await controller.updateFidoUser(
+      { user: { email: 'Owner@Example.com' } },
+      { credentialId: 'credential-id', deviceFriendlyName: 'phone', userName: 'owner' },
+      'credential-id',
+      response() as never
+    );
+    expect(fidoService.updateFidoUser).toHaveBeenCalledWith(expect.any(Object), 'credential-id', 'owner@example.com');
   });
 });

--- a/apps/api-gateway/src/fido/fido.controller.spec.ts
+++ b/apps/api-gateway/src/fido/fido.controller.spec.ts
@@ -1,0 +1,55 @@
+import { ForbiddenException } from '@nestjs/common';
+import { FidoController } from './fido.controller';
+
+const response = (): { status: jest.Mock; json: jest.Mock } => {
+  const res = {
+    status: jest.fn(),
+    json: jest.fn()
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  return res;
+};
+
+describe('FidoController passkey management authorization', () => {
+  const fidoService = {
+    fetchFidoUserDetails: jest.fn(),
+    updateFidoUserDeviceName: jest.fn(),
+    deleteFidoUserDevice: jest.fn()
+  };
+  const controller = new FidoController(fidoService as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('rejects access to another user passkey details', async () => {
+    await expect(
+      controller.fetchFidoUserDetails(
+        { user: { email: 'owner@example.com' } },
+        'other@example.com',
+        response() as never
+      )
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(fidoService.fetchFidoUserDetails).not.toHaveBeenCalled();
+  });
+
+  it('passes the authenticated identity to device updates', async () => {
+    fidoService.updateFidoUserDeviceName.mockResolvedValue({ response: 'updated' });
+    await controller.updateFidoUserDeviceName(
+      { user: { email: 'Owner@Example.com' } },
+      'credential-id',
+      'phone',
+      response() as never
+    );
+    expect(fidoService.updateFidoUserDeviceName).toHaveBeenCalledWith('credential-id', 'phone', 'owner@example.com');
+  });
+
+  it('passes the authenticated identity to device deletion', async () => {
+    fidoService.deleteFidoUserDevice.mockResolvedValue({ response: 'deleted' });
+    await controller.deleteFidoUserDevice(
+      { user: { email: 'owner@example.com' } },
+      'credential-id',
+      response() as never
+    );
+    expect(fidoService.deleteFidoUserDevice).toHaveBeenCalledWith('credential-id', 'owner@example.com');
+  });
+});

--- a/apps/api-gateway/src/fido/fido.controller.ts
+++ b/apps/api-gateway/src/fido/fido.controller.ts
@@ -5,13 +5,15 @@ import {
   Get,
   HttpStatus,
   Logger,
+  ForbiddenException,
   Param,
   Post,
   Put,
   Query,
   Request,
   Res,
-  UseFilters
+  UseFilters,
+  UseGuards
 } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
@@ -42,6 +44,7 @@ import { Response } from 'express';
 import { Roles } from '../authz/decorators/roles.decorator';
 import { OrgRoles } from 'libs/org-roles/enums';
 import { CustomExceptionFilter } from 'apps/api-gateway/common/exception-handler';
+import { AuthGuard } from '@nestjs/passport';
 
 @UseFilters(CustomExceptionFilter)
 @Controller('auth')
@@ -60,8 +63,7 @@ export class FidoController {
    * @returns User details
    */
   @Get('/passkey/:email')
-  // TODO: Check if roles are required here?
-  // @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
+  @UseGuards(AuthGuard('jwt'))
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.HOLDER, OrgRoles.ISSUER, OrgRoles.SUPER_ADMIN, OrgRoles.MEMBER)
   @ApiBearerAuth()
   @ApiOperation({
@@ -74,7 +76,11 @@ export class FidoController {
   @ApiBadRequestResponse({ description: 'Bad Request', type: BadRequestErrorDto })
   async fetchFidoUserDetails(@Request() req, @Param('email') email: string, @Res() res: Response): Promise<Response> {
     try {
-      const fidoUserDetails = await this.fidoService.fetchFidoUserDetails(email.toLowerCase());
+      const authenticatedEmail = this.getAuthenticatedEmail(req);
+      if (authenticatedEmail !== email.toLowerCase()) {
+        throw new ForbiddenException('Passkey details can only be accessed by their owner');
+      }
+      const fidoUserDetails = await this.fidoService.fetchFidoUserDetails(authenticatedEmail);
       const finalResponse: IResponseType = {
         statusCode: HttpStatus.OK,
         message: ResponseMessages.user.success.fetchUsers,
@@ -241,19 +247,23 @@ export class FidoController {
    */
   @Put('/passkey/:credentialId')
   @ApiBearerAuth()
-  // TODO: Check if roles are required here?
-  // @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
+  @UseGuards(AuthGuard('jwt'))
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.HOLDER, OrgRoles.ISSUER, OrgRoles.SUPER_ADMIN, OrgRoles.MEMBER)
   @ApiOperation({ summary: 'Update fido user device name', description: 'Update the device name of a FIDO user.' })
   @ApiQuery({ name: 'deviceName', required: true })
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   async updateFidoUserDeviceName(
+    @Request() req,
     @Param('credentialId') credentialId: string,
     @Query('deviceName') deviceName: string,
     @Res() res: Response
   ): Promise<Response> {
     try {
-      const updateDeviceName = await this.fidoService.updateFidoUserDeviceName(credentialId, deviceName);
+      const updateDeviceName = await this.fidoService.updateFidoUserDeviceName(
+        credentialId,
+        deviceName,
+        this.getAuthenticatedEmail(req)
+      );
       const finalResponse: IResponseType = {
         statusCode: HttpStatus.OK,
         message: ResponseMessages.fido.success.updateDeviceName,
@@ -274,14 +284,17 @@ export class FidoController {
    */
   @Delete('/passkey/:credentialId')
   @ApiBearerAuth()
-  // TODO: Check if roles are required here?
-  // @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
+  @UseGuards(AuthGuard('jwt'))
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.HOLDER, OrgRoles.ISSUER, OrgRoles.SUPER_ADMIN, OrgRoles.MEMBER)
   @ApiOperation({ summary: 'Delete fido user device', description: 'Delete a FIDO user device by its credential ID.' })
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
-  async deleteFidoUserDevice(@Param('credentialId') credentialId: string, @Res() res: Response): Promise<Response> {
+  async deleteFidoUserDevice(
+    @Request() req,
+    @Param('credentialId') credentialId: string,
+    @Res() res: Response
+  ): Promise<Response> {
     try {
-      const deleteFidoUser = await this.fidoService.deleteFidoUserDevice(credentialId);
+      const deleteFidoUser = await this.fidoService.deleteFidoUserDevice(credentialId, this.getAuthenticatedEmail(req));
       const finalResponse: IResponseType = {
         statusCode: HttpStatus.OK,
         message: ResponseMessages.fido.success.deleteDevice,
@@ -292,5 +305,13 @@ export class FidoController {
       this.logger.error(`Error::${error}`);
       throw error;
     }
+  }
+
+  private getAuthenticatedEmail(req): string {
+    const email = req?.user?.email;
+    if ('string' !== typeof email || !email.trim()) {
+      throw new ForbiddenException('Authenticated user email is required for passkey management');
+    }
+    return email.trim().toLowerCase();
   }
 }

--- a/apps/api-gateway/src/fido/fido.controller.ts
+++ b/apps/api-gateway/src/fido/fido.controller.ts
@@ -102,19 +102,27 @@ export class FidoController {
    */
   @Post('/passkey/generate-registration/:email')
   @ApiExcludeEndpoint()
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.HOLDER, OrgRoles.ISSUER, OrgRoles.SUPER_ADMIN, OrgRoles.MEMBER)
   @ApiOperation({
     summary: 'Generate registration option',
     description: 'Generate registration options for a FIDO user.'
   })
   @ApiResponse({ status: HttpStatus.CREATED, description: 'Success', type: ApiResponseDto })
   async generateRegistrationOption(
+    @Request() req,
     @Body() body: GenerateRegistrationDto,
     @Param('email') email: string,
     @Res() res: Response
   ): Promise<Response> {
     try {
+      const authenticatedEmail = this.getAuthenticatedEmail(req);
+      if (authenticatedEmail !== email.toLowerCase()) {
+        throw new ForbiddenException('Passkey registration can only be completed by its owner');
+      }
       const { deviceFlag } = body;
-      const registrationOption = await this.fidoService.generateRegistrationOption(deviceFlag, email.toLowerCase());
+      const registrationOption = await this.fidoService.generateRegistrationOption(deviceFlag, authenticatedEmail);
       const finalResponse: IResponseType = {
         statusCode: HttpStatus.CREATED,
         message: ResponseMessages.fido.success.RegistrationOption,
@@ -136,6 +144,9 @@ export class FidoController {
    */
   @Post('/passkey/verify-registration/:email')
   @ApiExcludeEndpoint()
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.HOLDER, OrgRoles.ISSUER, OrgRoles.SUPER_ADMIN, OrgRoles.MEMBER)
   @ApiOperation({ summary: 'Verify registration', description: 'Verify the registration of a FIDO user.' })
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   async verifyRegistration(
@@ -144,7 +155,11 @@ export class FidoController {
     @Param('email') email: string,
     @Res() res: Response
   ): Promise<Response> {
-    const verifyRegistration = await this.fidoService.verifyRegistration(verifyRegistrationDto, email.toLowerCase());
+    const authenticatedEmail = this.getAuthenticatedEmail(req);
+    if (authenticatedEmail !== email.toLowerCase()) {
+      throw new ForbiddenException('Passkey registration can only be completed by its owner');
+    }
+    const verifyRegistration = await this.fidoService.verifyRegistration(verifyRegistrationDto, authenticatedEmail);
     const finalResponse: IResponseType = {
       statusCode: HttpStatus.OK,
       message: ResponseMessages.fido.success.verifyRegistration,
@@ -218,6 +233,9 @@ export class FidoController {
    */
   @Put('/passkey/user-details/:credentialId')
   @ApiExcludeEndpoint()
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.HOLDER, OrgRoles.ISSUER, OrgRoles.SUPER_ADMIN, OrgRoles.MEMBER)
   @ApiOperation({ summary: 'Update fido user details', description: 'Update the details of a FIDO user.' })
   @ApiResponse({ status: HttpStatus.OK, description: 'Success', type: ApiResponseDto })
   async updateFidoUser(
@@ -228,7 +246,8 @@ export class FidoController {
   ): Promise<Response> {
     const verifyRegistration = await this.fidoService.updateFidoUser(
       updateFidoUserDetailsDto,
-      decodeURIComponent(credentialId)
+      decodeURIComponent(credentialId),
+      this.getAuthenticatedEmail(req)
     );
     const finalResponse: IResponseType = {
       statusCode: HttpStatus.OK,

--- a/apps/api-gateway/src/fido/fido.service.ts
+++ b/apps/api-gateway/src/fido/fido.service.ts
@@ -47,9 +47,10 @@ export class FidoService extends BaseService {
 
   async updateFidoUser(
     updateFidoUserDetailsDto: UpdateFidoUserDetailsDto,
-    credentialId: string
+    credentialId: string,
+    actorEmail: string
   ): Promise<{ response: object }> {
-    const payload = { updateFidoUserDetailsDto, credentialId };
+    const payload = { updateFidoUserDetailsDto, credentialId, actorEmail };
     return this.natsClient.sendNats(this.fidoServiceProxy, 'update-user', payload);
   }
 

--- a/apps/api-gateway/src/fido/fido.service.ts
+++ b/apps/api-gateway/src/fido/fido.service.ts
@@ -58,13 +58,17 @@ export class FidoService extends BaseService {
     return this.natsClient.sendNats(this.fidoServiceProxy, 'fetch-fido-user-details', payload);
   }
 
-  async deleteFidoUserDevice(credentialId: string): Promise<{ response: object }> {
-    const payload = { credentialId };
+  async deleteFidoUserDevice(credentialId: string, actorEmail: string): Promise<{ response: object }> {
+    const payload = { credentialId, actorEmail };
     return this.natsClient.sendNats(this.fidoServiceProxy, 'delete-fido-user-device', payload);
   }
 
-  async updateFidoUserDeviceName(credentialId: string, deviceName: string): Promise<{ response: string }> {
-    const payload = { credentialId, deviceName };
+  async updateFidoUserDeviceName(
+    credentialId: string,
+    deviceName: string,
+    actorEmail: string
+  ): Promise<{ response: string }> {
+    const payload = { credentialId, deviceName, actorEmail };
     return this.natsClient.sendNats(this.fidoServiceProxy, 'update-fido-user-device-name', payload);
   }
 }

--- a/apps/oid4vc-issuance/src/oid4vc-issuance.service.ts
+++ b/apps/oid4vc-issuance/src/oid4vc-issuance.service.ts
@@ -650,6 +650,7 @@ export class Oid4vcIssuanceService {
   ): Promise<any> {
     let buildOidcCredentialOffer: CredentialOfferPayload;
     const newlyAllocatedIndices: { listId: string; index: number }[] = [];
+    let offerCreated = false;
     try {
       const filterTemplateIds = extractTemplateIds(createOidcCredentialOffer);
       if (!filterTemplateIds) {
@@ -774,6 +775,7 @@ export class Oid4vcIssuanceService {
       if (!createCredentialOfferOnAgent) {
         throw new NotFoundException(ResponseMessages.oidcIssuerSession.error.errorCreateOffer);
       }
+      offerCreated = true;
 
       // Logic to add noticeUrl in response from agent if it is present in template or request payload
       const { response } = createCredentialOfferOnAgent;
@@ -823,7 +825,11 @@ export class Oid4vcIssuanceService {
 
       return createCredentialOfferOnAgent.response;
     } catch (error) {
-      for (const alloc of newlyAllocatedIndices) {
+      if (offerCreated && 0 < newlyAllocatedIndices.length) {
+        this.logger.error('Status-list allocations were retained because credential offer creation succeeded before local persistence failed');
+      }
+      const allocationsToRelease = offerCreated ? [] : newlyAllocatedIndices;
+      for (const alloc of allocationsToRelease) {
         try {
           await this.statusListAllocatorService.release(alloc.listId, alloc.index);
         } catch (releaseErr) {
@@ -842,6 +848,7 @@ export class Oid4vcIssuanceService {
 
   async createOidcCredentialOfferD2A(oidcCredentialD2APayload, orgId: string): Promise<object | string> {
     const newlyAllocatedIndices: { listId: string; index: number }[] = [];
+    let offerCreated = false;
     try {
       for (const credential of oidcCredentialD2APayload.credentials) {
         const { signerOptions } = credential;
@@ -910,6 +917,7 @@ export class Oid4vcIssuanceService {
       if (!createCredentialOfferOnAgent) {
         throw new NotFoundException(ResponseMessages.oidcIssuerSession.error.errorCreateOffer);
       }
+      offerCreated = true;
 
       let parsedResponse;
       if ('string' === typeof createCredentialOfferOnAgent.response) {
@@ -941,7 +949,11 @@ export class Oid4vcIssuanceService {
 
       return createCredentialOfferOnAgent.response;
     } catch (error) {
-      for (const alloc of newlyAllocatedIndices) {
+      if (offerCreated && 0 < newlyAllocatedIndices.length) {
+        this.logger.error('Status-list allocations were retained because credential offer creation succeeded before local persistence failed');
+      }
+      const allocationsToRelease = offerCreated ? [] : newlyAllocatedIndices;
+      for (const alloc of allocationsToRelease) {
         try {
           await this.statusListAllocatorService.release(alloc.listId, alloc.index);
         } catch (releaseErr) {

--- a/apps/oid4vc-issuance/src/status-list-allocator.service.spec.ts
+++ b/apps/oid4vc-issuance/src/status-list-allocator.service.spec.ts
@@ -43,6 +43,9 @@ describe('StatusListAllocatorService', () => {
         update: jest.fn(() => Promise.resolve(activeList)),
         updateMany: jest.fn(),
         create: jest.fn()
+      },
+      issued_oid4vc_credentials: {
+        deleteMany: jest.fn()
       }
     };
     const prisma = {
@@ -58,5 +61,82 @@ describe('StatusListAllocatorService', () => {
     expect(calls.slice(0, 2)).toEqual(['lock', 'find']);
     expect(result.listId).toBe(activeList.listId);
     expect(tx.status_list_allocation.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('commits full-list deactivation before reporting the bitmap is full', async () => {
+    const activeList = {
+      id: 'allocation-id',
+      orgId: 'org-id',
+      issuerDid: 'did:example:issuer',
+      listId: '00000000-0000-0000-0000-000000000001',
+      listSize: 8,
+      allocatedCount: 0,
+      bitmap: Buffer.from([0b11111111]),
+      isActive: true
+    };
+    const tx = {
+      $executeRaw: jest.fn(() => Promise.resolve(1)),
+      status_list_allocation: {
+        findFirst: jest.fn(() => Promise.resolve(activeList)),
+        update: jest.fn(() => Promise.resolve(activeList)),
+        updateMany: jest.fn(() => Promise.resolve({ count: 1 })),
+        create: jest.fn()
+      }
+    };
+    const prisma = {
+      $transaction: jest.fn((callback) => callback(tx))
+    };
+
+    await expect(
+      new StatusListAllocatorService(prisma as never).allocate(
+        activeList.orgId,
+        activeList.issuerDid,
+        activeList.listSize
+      )
+    ).rejects.toThrow('Status list bitmap is full');
+    expect(tx.status_list_allocation.update).toHaveBeenCalledWith({
+      where: { id: activeList.id },
+      data: { isActive: false }
+    });
+  });
+
+  it('removes a persisted credential before releasing its status-list slot', async () => {
+    const calls: string[] = [];
+    const allocation = {
+      id: 'allocation-id',
+      orgId: 'org-id',
+      issuerDid: 'did:example:issuer',
+      listId: '00000000-0000-0000-0000-000000000001',
+      listSize: 8,
+      allocatedCount: 1,
+      bitmap: Buffer.from([0b00000001]),
+      isActive: true
+    };
+    const tx = {
+      $executeRaw: jest.fn(() => Promise.resolve(1)),
+      issued_oid4vc_credentials: {
+        deleteMany: jest.fn(() => {
+          calls.push('delete-credential');
+          return Promise.resolve({ count: 1 });
+        })
+      },
+      status_list_allocation: {
+        findUnique: jest.fn(() => Promise.resolve(allocation)),
+        update: jest.fn(() => {
+          calls.push('release-slot');
+          return Promise.resolve(allocation);
+        })
+      }
+    };
+    const prisma = {
+      $transaction: jest.fn((callback) => callback(tx))
+    };
+
+    await new StatusListAllocatorService(prisma as never).release(allocation.listId, 0);
+
+    expect(tx.issued_oid4vc_credentials.deleteMany).toHaveBeenCalledWith({
+      where: { listId: allocation.listId, index: 0 }
+    });
+    expect(calls).toEqual(['delete-credential', 'release-slot']);
   });
 });

--- a/apps/oid4vc-issuance/src/status-list-allocator.service.spec.ts
+++ b/apps/oid4vc-issuance/src/status-list-allocator.service.spec.ts
@@ -75,6 +75,13 @@ describe('StatusListAllocatorService', () => {
       bitmap: Buffer.from([0b11111111]),
       isActive: true
     };
+    const replacementList = {
+      ...activeList,
+      id: 'replacement-allocation-id',
+      listId: '00000000-0000-0000-0000-000000000002',
+      allocatedCount: 0,
+      bitmap: Buffer.from([0])
+    };
     const tx = {
       $executeRaw: jest.fn(() => Promise.resolve(1)),
       status_list_allocation: {
@@ -84,7 +91,7 @@ describe('StatusListAllocatorService', () => {
           return Promise.resolve(activeList);
         }),
         updateMany: jest.fn(() => Promise.resolve({ count: 1 })),
-        create: jest.fn()
+        create: jest.fn(() => Promise.resolve(replacementList))
       }
     };
     const prisma = {
@@ -101,12 +108,9 @@ describe('StatusListAllocatorService', () => {
         activeList.issuerDid,
         activeList.listSize
       )
-    ).rejects.toThrow('Status list bitmap is full');
-    expect(tx.status_list_allocation.update).toHaveBeenCalledWith({
-      where: { id: activeList.id },
-      data: { isActive: false }
-    });
-    expect(calls).toEqual(['deactivate', 'commit']);
+    ).resolves.toEqual({ listId: replacementList.listId, index: expect.any(Number) });
+    expect(tx.status_list_allocation.updateMany).toHaveBeenCalledTimes(1);
+    expect(calls).toContain('commit');
   });
 
   it('removes a persisted credential before releasing its status-list slot', async () => {

--- a/apps/oid4vc-issuance/src/status-list-allocator.service.spec.ts
+++ b/apps/oid4vc-issuance/src/status-list-allocator.service.spec.ts
@@ -122,7 +122,17 @@ describe('StatusListAllocatorService', () => {
       isActive: true
     };
     const tx = {
-      $executeRaw: jest.fn(() => Promise.resolve(1)),
+      $executeRaw: jest.fn((strings: TemplateStringsArray) => {
+        const query = strings.join('');
+        if (query.includes('issued_oid4vc_credentials')) {
+          calls.push('lock-credentials');
+        } else if (query.includes('status_list_allocation')) {
+          calls.push('lock-allocation');
+        } else {
+          calls.push('lock-advisory');
+        }
+        return Promise.resolve(1);
+      }),
       issued_oid4vc_credentials: {
         deleteMany: jest.fn(() => {
           calls.push('delete-credential');
@@ -146,6 +156,12 @@ describe('StatusListAllocatorService', () => {
     expect(tx.issued_oid4vc_credentials.deleteMany).toHaveBeenCalledWith({
       where: { listId: allocation.listId, index: 0 }
     });
-    expect(calls).toEqual(['delete-credential', 'release-slot']);
+    expect(calls).toEqual([
+      'lock-credentials',
+      'lock-allocation',
+      'lock-advisory',
+      'delete-credential',
+      'release-slot'
+    ]);
   });
 });

--- a/apps/oid4vc-issuance/src/status-list-allocator.service.spec.ts
+++ b/apps/oid4vc-issuance/src/status-list-allocator.service.spec.ts
@@ -64,6 +64,7 @@ describe('StatusListAllocatorService', () => {
   });
 
   it('commits full-list deactivation before reporting the bitmap is full', async () => {
+    const calls: string[] = [];
     const activeList = {
       id: 'allocation-id',
       orgId: 'org-id',
@@ -78,13 +79,20 @@ describe('StatusListAllocatorService', () => {
       $executeRaw: jest.fn(() => Promise.resolve(1)),
       status_list_allocation: {
         findFirst: jest.fn(() => Promise.resolve(activeList)),
-        update: jest.fn(() => Promise.resolve(activeList)),
+        update: jest.fn(() => {
+          calls.push('deactivate');
+          return Promise.resolve(activeList);
+        }),
         updateMany: jest.fn(() => Promise.resolve({ count: 1 })),
         create: jest.fn()
       }
     };
     const prisma = {
-      $transaction: jest.fn((callback) => callback(tx))
+      $transaction: jest.fn(async (callback) => {
+        const result = await callback(tx);
+        calls.push('commit');
+        return result;
+      })
     };
 
     await expect(
@@ -98,6 +106,7 @@ describe('StatusListAllocatorService', () => {
       where: { id: activeList.id },
       data: { isActive: false }
     });
+    expect(calls).toEqual(['deactivate', 'commit']);
   });
 
   it('removes a persisted credential before releasing its status-list slot', async () => {

--- a/apps/oid4vc-issuance/src/status-list-allocator.service.spec.ts
+++ b/apps/oid4vc-issuance/src/status-list-allocator.service.spec.ts
@@ -1,0 +1,62 @@
+/* eslint-disable camelcase */
+import { RandomBitmapIndexAllocator, StatusListAllocatorService } from './status-list-allocator.service';
+
+describe('RandomBitmapIndexAllocator', () => {
+  it('does not allocate an existing index', () => {
+    const allocator = new RandomBitmapIndexAllocator(8, new Uint8Array([0b11111110]));
+    expect(allocator.allocate()).toBe(0);
+    expect(allocator.getAllocatedCount()).toBe(8);
+    expect(() => allocator.allocate()).toThrow('No indexes left');
+  });
+
+  it('releases an allocated index', () => {
+    const allocator = new RandomBitmapIndexAllocator(8, new Uint8Array([0b00000001]));
+    allocator.release(0);
+    expect(allocator.isIndexAllocated(0)).toBe(false);
+    expect(allocator.getAllocatedCount()).toBe(0);
+  });
+});
+
+describe('StatusListAllocatorService', () => {
+  it('takes a transaction-scoped lock before reading the active list', async () => {
+    const calls: string[] = [];
+    const activeList = {
+      id: 'allocation-id',
+      orgId: 'org-id',
+      issuerDid: 'did:example:issuer',
+      listId: '00000000-0000-0000-0000-000000000001',
+      listSize: 8,
+      allocatedCount: 0,
+      bitmap: Buffer.from([0]),
+      isActive: true
+    };
+    const tx = {
+      $executeRaw: jest.fn(() => {
+        calls.push('lock');
+        return Promise.resolve(1);
+      }),
+      status_list_allocation: {
+        findFirst: jest.fn(() => {
+          calls.push('find');
+          return Promise.resolve(activeList);
+        }),
+        update: jest.fn(() => Promise.resolve(activeList)),
+        updateMany: jest.fn(),
+        create: jest.fn()
+      }
+    };
+    const prisma = {
+      $transaction: jest.fn((callback) => callback(tx))
+    };
+
+    const result = await new StatusListAllocatorService(prisma as never).allocate(
+      activeList.orgId,
+      activeList.issuerDid,
+      activeList.listSize
+    );
+
+    expect(calls.slice(0, 2)).toEqual(['lock', 'find']);
+    expect(result.listId).toBe(activeList.listId);
+    expect(tx.status_list_allocation.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/oid4vc-issuance/src/status-list-allocator.service.ts
+++ b/apps/oid4vc-issuance/src/status-list-allocator.service.ts
@@ -125,14 +125,6 @@ export class StatusListAllocatorService {
       });
 
       if (!activeList) {
-        // Mark inactive if full
-        if (activeList) {
-          await tx.status_list_allocation.updateMany({
-            where: { orgId, issuerDid, isActive: true },
-            data: { isActive: false }
-          });
-        }
-
         activeList = await tx.status_list_allocation.create({
           data: {
             orgId,

--- a/apps/oid4vc-issuance/src/status-list-allocator.service.ts
+++ b/apps/oid4vc-issuance/src/status-list-allocator.service.ts
@@ -209,6 +209,11 @@ export class StatusListAllocatorService {
 
   async release(listId: string, index: number): Promise<void> {
     await this.prisma.$transaction(async (tx) => {
+      // Use the same relation lock order as the migration before reading either table.
+      // ROW SHARE establishes order without serializing normal allocation writes.
+      await tx.$executeRaw`LOCK TABLE "issued_oid4vc_credentials" IN ROW SHARE MODE`;
+      await tx.$executeRaw`LOCK TABLE "status_list_allocation" IN ROW SHARE MODE`;
+
       let allocation = await tx.status_list_allocation.findUnique({
         where: { listId }
       });

--- a/apps/oid4vc-issuance/src/status-list-allocator.service.ts
+++ b/apps/oid4vc-issuance/src/status-list-allocator.service.ts
@@ -112,7 +112,7 @@ export class StatusListAllocatorService {
       throw new Error('orgId and issuerDid are required for status list allocation');
     }
     const defaultListSize = CommonConstants.DEFAULT_STATUS_LIST_SIZE;
-    return this.prisma.$transaction(async (tx) => {
+    const allocation = await this.prisma.$transaction(async (tx) => {
       // Serialize allocations for the same tenant and issuer. A database-level lock is
       // required because multiple service replicas can execute this code concurrently.
       const allocationLockKey = `${orgId}:${issuerDid}`;
@@ -168,11 +168,17 @@ export class StatusListAllocatorService {
             where: { id: activeList.id },
             data: { isActive: false }
           });
-          throw new Error('Status list bitmap is full');
+          return undefined;
         }
         throw error;
       }
     });
+
+    if (!allocation) {
+      throw new Error('Status list bitmap is full');
+    }
+
+    return allocation;
   }
 
   async saveCredentialAllocation(
@@ -223,6 +229,11 @@ export class StatusListAllocatorService {
 
       const allocator = new RandomBitmapIndexAllocator(allocation.listSize, new Uint8Array(allocation.bitmap));
       allocator.release(index);
+
+      // A previously persisted credential must be removed before its slot can be reused.
+      await tx.issued_oid4vc_credentials.deleteMany({
+        where: { listId, index }
+      });
 
       await tx.status_list_allocation.update({
         where: { id: allocation.id },

--- a/apps/oid4vc-issuance/src/status-list-allocator.service.ts
+++ b/apps/oid4vc-issuance/src/status-list-allocator.service.ts
@@ -124,7 +124,7 @@ export class StatusListAllocatorService {
         orderBy: { createDateTime: 'desc' }
       });
 
-      if (!activeList || activeList.allocatedCount >= activeList.listSize) {
+      if (!activeList) {
         // Mark inactive if full
         if (activeList) {
           await tx.status_list_allocation.updateMany({
@@ -146,7 +146,26 @@ export class StatusListAllocatorService {
         });
       }
 
-      const allocator = new RandomBitmapIndexAllocator(activeList.listSize, new Uint8Array(activeList.bitmap));
+      let allocator = new RandomBitmapIndexAllocator(activeList.listSize, new Uint8Array(activeList.bitmap));
+
+      if (allocator.getAllocatedCount() >= activeList.listSize) {
+        await tx.status_list_allocation.updateMany({
+          where: { orgId, issuerDid, isActive: true },
+          data: { isActive: false }
+        });
+        activeList = await tx.status_list_allocation.create({
+          data: {
+            orgId,
+            issuerDid,
+            listId: randomUUID(),
+            listSize: listSize || defaultListSize,
+            allocatedCount: 0,
+            bitmap: Buffer.from(new Uint8Array(Math.ceil((listSize || defaultListSize) / 8))),
+            isActive: true
+          }
+        });
+        allocator = new RandomBitmapIndexAllocator(activeList.listSize, new Uint8Array(activeList.bitmap));
+      }
 
       try {
         const index = allocator.allocate();

--- a/apps/oid4vc-issuance/src/status-list-allocator.service.ts
+++ b/apps/oid4vc-issuance/src/status-list-allocator.service.ts
@@ -113,16 +113,22 @@ export class StatusListAllocatorService {
     }
     const defaultListSize = CommonConstants.DEFAULT_STATUS_LIST_SIZE;
     return this.prisma.$transaction(async (tx) => {
+      // Serialize allocations for the same tenant and issuer. A database-level lock is
+      // required because multiple service replicas can execute this code concurrently.
+      const allocationLockKey = `${orgId}:${issuerDid}`;
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${allocationLockKey}, 0))`;
+
       // Find active list or create one
       let activeList = await tx.status_list_allocation.findFirst({
-        where: { orgId, issuerDid, isActive: true }
+        where: { orgId, issuerDid, isActive: true },
+        orderBy: { createDateTime: 'desc' }
       });
 
       if (!activeList || activeList.allocatedCount >= activeList.listSize) {
         // Mark inactive if full
         if (activeList) {
-          await tx.status_list_allocation.update({
-            where: { id: activeList.id },
+          await tx.status_list_allocation.updateMany({
+            where: { orgId, issuerDid, isActive: true },
             data: { isActive: false }
           });
         }
@@ -157,12 +163,12 @@ export class StatusListAllocatorService {
         return { listId: activeList.listId, index };
       } catch (error) {
         if ('No indexes left' === error.message) {
-          // Retry rotation if we hit the race condition limit
+          // A mismatched bitmap/count should not leave a full list active.
           await tx.status_list_allocation.update({
             where: { id: activeList.id },
             data: { isActive: false }
           });
-          throw new Error('Retry allocation, list full');
+          throw new Error('Status list bitmap is full');
         }
         throw error;
       }
@@ -197,7 +203,17 @@ export class StatusListAllocatorService {
 
   async release(listId: string, index: number): Promise<void> {
     await this.prisma.$transaction(async (tx) => {
-      const allocation = await tx.status_list_allocation.findUnique({
+      let allocation = await tx.status_list_allocation.findUnique({
+        where: { listId }
+      });
+
+      if (!allocation) {
+        return;
+      }
+
+      const allocationLockKey = `${allocation.orgId}:${allocation.issuerDid}`;
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${allocationLockKey}, 0))`;
+      allocation = await tx.status_list_allocation.findUnique({
         where: { listId }
       });
 
@@ -209,7 +225,7 @@ export class StatusListAllocatorService {
       allocator.release(index);
 
       await tx.status_list_allocation.update({
-        where: { listId },
+        where: { id: allocation.id },
         data: {
           bitmap: Buffer.from(allocator.export()),
           allocatedCount: allocator.getAllocatedCount()

--- a/apps/user/repositories/user-device.repository.ts
+++ b/apps/user/repositories/user-device.repository.ts
@@ -16,11 +16,14 @@ type FidoMultiDevicePayload = {
 }[];
 @Injectable()
 export class UserDevicesRepository {
-  constructor(private readonly prisma: PrismaService, private readonly logger: Logger) { }
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly logger: Logger
+  ) {}
 
   /**
-   * 
-   * @param email 
+   *
+   * @param email
    * @returns User exist details
    */
 
@@ -29,7 +32,7 @@ export class UserDevicesRepository {
     try {
       return this.prisma.user_devices.findFirst({
         where: {
-          userId:String(userId)
+          userId: String(userId)
         }
       });
     } catch (error) {
@@ -39,25 +42,24 @@ export class UserDevicesRepository {
   }
 
   /**
-     * 
-     * @param createFidoMultiDevice
-     * @returns Device details
-     */
+   *
+   * @param createFidoMultiDevice
+   * @returns Device details
+   */
   // eslint-disable-next-line camelcase
-  async createMultiDevice(newDevice: Prisma.JsonValue, userId: string): Promise<user_devices> {
+  async createMultiDevice(newDevice: Prisma.JsonValue, userId: string, credentialId: string): Promise<user_devices> {
     try {
-
       const saveResponse = await this.prisma.user_devices.create({
         data: {
           devices: newDevice,
-          userId:String(userId),
+          userId: String(userId),
           createdBy: userId,
+          credentialId,
           lastChangedBy: userId
         }
       });
 
       return saveResponse;
-
     } catch (error) {
       this.logger.error(`In Create User Repository: ${JSON.stringify(error)}`);
       throw error;
@@ -65,16 +67,16 @@ export class UserDevicesRepository {
   }
 
   /**
-     * 
-     * @param userId
-     * @returns Device details
-     */
+   *
+   * @param userId
+   * @returns Device details
+   */
   // eslint-disable-next-line camelcase
   async fidoMultiDevice(userId: string): Promise<user_devices[]> {
     try {
       const userDetails = await this.prisma.user_devices.findMany({
         where: {
-          userId:String(userId),
+          userId: String(userId),
           deletedAt: null
         },
         orderBy: {
@@ -90,17 +92,16 @@ export class UserDevicesRepository {
   }
 
   /**
-     * 
-     * @param userId
-     * @returns Get all device details
-     */
+   *
+   * @param userId
+   * @returns Get all device details
+   */
   // eslint-disable-next-line camelcase, @typescript-eslint/no-explicit-any
   async getfidoMultiDevice(userId: string): Promise<user_devices[]> {
     try {
-
       const fidoMultiDevice = await this.prisma.user_devices.findMany({
         where: {
-          userId:String(userId)
+          userId: String(userId)
         }
       });
       return fidoMultiDevice;
@@ -111,15 +112,15 @@ export class UserDevicesRepository {
   }
 
   /**
-     * 
-     * @param userId
-     * @returns Get all active device details
-     */
+   *
+   * @param userId
+   * @returns Get all active device details
+   */
   async getfidoMultiDeviceDetails(userId: string): Promise<FidoMultiDevicePayload> {
     try {
       const fidoMultiDevice = await this.prisma.user_devices.findMany({
         where: {
-          userId:String(userId),
+          userId: String(userId),
           deletedAt: null
         },
         select: {
@@ -141,10 +142,10 @@ export class UserDevicesRepository {
   }
 
   /**
-     * 
-     * @param credentialId
-     * @returns Find device details from credentialID
-     */
+   *
+   * @param credentialId
+   * @returns Find device details from credentialID
+   */
   async getFidoUserDeviceDetails(credentialId: string): Promise<unknown> {
     try {
       const getUserDevice = await this.prisma.$queryRaw`
@@ -160,11 +161,11 @@ export class UserDevicesRepository {
   }
 
   /**
-     * 
-     * @param credentialId 
-     * @param loginCounter
-     * @returns Update Auth counter
-     */
+   *
+   * @param credentialId
+   * @param loginCounter
+   * @returns Update Auth counter
+   */
   async updateFidoAuthCounter(credentialId: string, loginCounter: number): Promise<Prisma.BatchPayload> {
     try {
       return await this.prisma.user_devices.updateMany({
@@ -175,7 +176,6 @@ export class UserDevicesRepository {
           authCounter: loginCounter
         }
       });
-
     } catch (error) {
       this.logger.error(`Not Found: ${JSON.stringify(error)}`);
       throw new NotFoundException(error);
@@ -183,10 +183,10 @@ export class UserDevicesRepository {
   }
 
   /**
-     * 
-     * @param credentialId 
-     * @returns Device detail for specific credentialId
-     */
+   *
+   * @param credentialId
+   * @returns Device detail for specific credentialId
+   */
   // eslint-disable-next-line camelcase
   async checkUserDeviceByCredentialId(credentialId: string): Promise<user_devices> {
     try {
@@ -202,10 +202,10 @@ export class UserDevicesRepository {
   }
 
   /**
-     * 
-     * @param credentialId 
-     * @returns Delete device
-     */
+   *
+   * @param credentialId
+   * @returns Delete device
+   */
   // eslint-disable-next-line camelcase
   async deleteUserDeviceByCredentialId(credentialId: string): Promise<Prisma.BatchPayload> {
     try {
@@ -223,11 +223,11 @@ export class UserDevicesRepository {
     }
   }
   /**
-     * 
-     * @param id 
-     * @param deviceName
-     * @returns Update device name
-     */
+   *
+   * @param id
+   * @param deviceName
+   * @returns Update device name
+   */
   async updateUserDeviceByCredentialId(id: string, deviceName: string): Promise<Prisma.BatchPayload> {
     try {
       return await this.prisma.user_devices.updateMany({
@@ -245,11 +245,11 @@ export class UserDevicesRepository {
   }
 
   /**
-     * 
-     * @param credentialId
-     * @param deviceFriendlyName 
-     * @returns Get device details name for specific credentialId
-     */
+   *
+   * @param credentialId
+   * @param deviceFriendlyName
+   * @returns Get device details name for specific credentialId
+   */
   async updateDeviceByCredentialId(credentialId: string): Promise<Prisma.BatchPayload> {
     try {
       return await this.prisma.$queryRaw`
@@ -263,15 +263,14 @@ export class UserDevicesRepository {
   }
 
   /**
-     * 
-     * @param id 
-     * @param credentialId
-     * @param deviceFriendlyName 
-     * @returns Update device name for specific credentialId
-     */
+   *
+   * @param id
+   * @param credentialId
+   * @param deviceFriendlyName
+   * @returns Update device name for specific credentialId
+   */
   // eslint-disable-next-line camelcase
   async addCredentialIdAndNameById(id: string, updateFidoUserDetails: string): Promise<user_devices> {
-
     try {
       return await this.prisma.user_devices.update({
         where: {
@@ -287,5 +286,4 @@ export class UserDevicesRepository {
       throw new InternalServerErrorException(error);
     }
   }
-
 }

--- a/apps/user/src/fido/dtos/fido-user.dto.ts
+++ b/apps/user/src/fido/dtos/fido-user.dto.ts
@@ -136,6 +136,19 @@ export class UpdateFidoUserDetailsDto {
   deviceFriendlyName: string;
 }
 
+export class UpdateFidoUserPayloadDto {
+  @ApiProperty()
+  updateFidoUserDetailsDto: UpdateFidoUserDetailsDto;
+
+  @ApiProperty()
+  @IsString()
+  credentialId: string;
+
+  @ApiProperty()
+  @IsString()
+  actorEmail: string;
+}
+
 export class UserNameDto {
   @ApiProperty()
   @IsString()

--- a/apps/user/src/fido/dtos/fido-user.dto.ts
+++ b/apps/user/src/fido/dtos/fido-user.dto.ts
@@ -1,160 +1,167 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsBoolean, IsOptional, IsString, ValidateNested } from 'class-validator';
 export class GenerateRegistrationDto {
-    email: string;
-    
-    @IsOptional()
-    @ApiProperty({ example: 'false' })
-    @IsBoolean({ message: 'isPasskey should be boolean' })
-    deviceFlag: boolean;
+  email: string;
+
+  @IsOptional()
+  @ApiProperty({ example: 'false' })
+  @IsBoolean({ message: 'isPasskey should be boolean' })
+  deviceFlag: boolean;
 }
 
 class ResponseDto {
-    @ApiProperty()
-    @IsString()
-    attestationObject: string;
-  
-    @ApiProperty()
-    @IsString()
-    clientDataJSON: string;
-  
-    @ApiProperty()
-    @IsArray()
-    transports: string[];
-  }
-  
-  class ClientExtensionResultsDto {
-    @ApiProperty()
-    @ValidateNested()
-    credProps: Record<string, unknown>;
-  }
-  
-  export class VerifyRegistrationDetailsDto {
-    @ApiProperty()
-    @IsString()
-    id: string;
-  
-    @ApiProperty()
-    @IsString()
-    rawId: string;
-  
-    @ApiProperty()
-    response: ResponseDto;
-  
-    @ApiProperty()
-    @IsString()
-    type: string;
-  
-    @ApiProperty()
-    clientExtensionResults: ClientExtensionResultsDto;
-  
-    @ApiProperty()
-    @IsString()
-    authenticatorAttachment: string;
-  
-    @ApiProperty()
-    @IsString()
-    challangeId: string;
-  }
-  
-  export class VerifyRegistrationPayloadDto {
-    @ApiProperty()
-    verifyRegistrationDetails: VerifyRegistrationDetailsDto;
-  
-    @ApiProperty()
-    @IsString()
-    email: string;
-  }
+  @ApiProperty()
+  @IsString()
+  attestationObject: string;
 
-  export class GenerateAuthentication {
-    userName: string;
-  }
+  @ApiProperty()
+  @IsString()
+  clientDataJSON: string;
 
-   
+  @ApiProperty()
+  @IsArray()
+  transports: string[];
+}
+
+class ClientExtensionResultsDto {
+  @ApiProperty()
+  @ValidateNested()
+  credProps: Record<string, unknown>;
+}
+
+export class VerifyRegistrationDetailsDto {
+  @ApiProperty()
+  @IsString()
+  id: string;
+
+  @ApiProperty()
+  @IsString()
+  rawId: string;
+
+  @ApiProperty()
+  response: ResponseDto;
+
+  @ApiProperty()
+  @IsString()
+  type: string;
+
+  @ApiProperty()
+  clientExtensionResults: ClientExtensionResultsDto;
+
+  @ApiProperty()
+  @IsString()
+  authenticatorAttachment: string;
+
+  @ApiProperty()
+  @IsString()
+  challangeId: string;
+}
+
+export class VerifyRegistrationPayloadDto {
+  @ApiProperty()
+  verifyRegistrationDetails: VerifyRegistrationDetailsDto;
+
+  @ApiProperty()
+  @IsString()
+  email: string;
+}
+
+export class GenerateAuthentication {
+  userName: string;
+}
+
 class VerifyAuthenticationResponseDto {
-    @ApiProperty()
-    @IsString()
-    authenticatorData: string;
-  
-    @ApiProperty()
-    @IsString()
-    clientDataJSON: string;
-  
-    @ApiProperty()
-    @IsString()
-    signature: string;
-  
-    @ApiProperty()
-    @IsString()
-    userHandle: string;
-  }
-  
-  export class VerifyAuthenticationDto {
-    @ApiProperty()
-    @IsString()
-    id: string;
-  
-    @ApiProperty()
-    @IsString()
-    rawId: string;
-  
-    @ApiProperty()
-    response: VerifyAuthenticationResponseDto;
-  
-    @ApiProperty()
-    @IsString()
-    type: string;
-  
-    @ApiProperty()
-    clientExtensionResults: ClientExtensionResultsDto;
-  
-    @ApiProperty()
-    @IsString()
-    authenticatorAttachment: string;
-  
-    @ApiProperty()
-    @IsString()
-    challangeId: string;
-  }
-  
-  export class VerifyAuthenticationPayloadDto {
-    @ApiProperty()
-    verifyAuthenticationDetails: VerifyAuthenticationDto;
-    email: string;
-  }
+  @ApiProperty()
+  @IsString()
+  authenticatorData: string;
 
-  export class UpdateFidoUserDetailsDto {
-    @ApiProperty()
-    @IsString()
-    userName: string;
-  
-    @ApiProperty()
-    @IsString()
-    credentialId: string;
-  
-    @ApiProperty()
-    @IsString()
-    deviceFriendlyName: string;
-  }
+  @ApiProperty()
+  @IsString()
+  clientDataJSON: string;
 
-  export class UserNameDto {
-    @ApiProperty()
-    @IsString()
-    email: string;
-  }
+  @ApiProperty()
+  @IsString()
+  signature: string;
 
-  export class credentialDto {
-    @ApiProperty()
-    @IsString()
-    credentialId: string;
-  }
+  @ApiProperty()
+  @IsString()
+  userHandle: string;
+}
 
-  export class updateDeviceDto {
-    @ApiProperty()
-    @IsString()
-    credentialId: string;
-    
-    @ApiProperty()
-    @IsString()
-    deviceName: string;
-  }
+export class VerifyAuthenticationDto {
+  @ApiProperty()
+  @IsString()
+  id: string;
+
+  @ApiProperty()
+  @IsString()
+  rawId: string;
+
+  @ApiProperty()
+  response: VerifyAuthenticationResponseDto;
+
+  @ApiProperty()
+  @IsString()
+  type: string;
+
+  @ApiProperty()
+  clientExtensionResults: ClientExtensionResultsDto;
+
+  @ApiProperty()
+  @IsString()
+  authenticatorAttachment: string;
+
+  @ApiProperty()
+  @IsString()
+  challangeId: string;
+}
+
+export class VerifyAuthenticationPayloadDto {
+  @ApiProperty()
+  verifyAuthenticationDetails: VerifyAuthenticationDto;
+  email: string;
+}
+
+export class UpdateFidoUserDetailsDto {
+  @ApiProperty()
+  @IsString()
+  userName: string;
+
+  @ApiProperty()
+  @IsString()
+  credentialId: string;
+
+  @ApiProperty()
+  @IsString()
+  deviceFriendlyName: string;
+}
+
+export class UserNameDto {
+  @ApiProperty()
+  @IsString()
+  email: string;
+}
+
+export class credentialDto {
+  @ApiProperty()
+  @IsString()
+  credentialId: string;
+
+  @ApiProperty()
+  @IsString()
+  actorEmail: string;
+}
+
+export class updateDeviceDto {
+  @ApiProperty()
+  @IsString()
+  credentialId: string;
+
+  @ApiProperty()
+  @IsString()
+  deviceName: string;
+
+  @ApiProperty()
+  @IsString()
+  actorEmail: string;
+}

--- a/apps/user/src/fido/fido.controller.ts
+++ b/apps/user/src/fido/fido.controller.ts
@@ -1,87 +1,97 @@
 import { Controller, Logger } from '@nestjs/common';
 import { MessagePattern } from '@nestjs/microservices';
-import { GenerateRegistrationDto, VerifyRegistrationPayloadDto, VerifyAuthenticationPayloadDto, UpdateFidoUserDetailsDto, UserNameDto, credentialDto, updateDeviceDto, GenerateAuthentication } from './dtos/fido-user.dto';
+import {
+  GenerateRegistrationDto,
+  VerifyRegistrationPayloadDto,
+  VerifyAuthenticationPayloadDto,
+  UpdateFidoUserPayloadDto,
+  UserNameDto,
+  credentialDto,
+  updateDeviceDto,
+  GenerateAuthentication
+} from './dtos/fido-user.dto';
 import { FidoService } from './fido.service';
 
 @Controller('fido')
 export class FidoController {
-    constructor(private readonly fidoService: FidoService) { }
-    private readonly logger = new Logger('PS-Fido-controller');
+  constructor(private readonly fidoService: FidoService) {}
+  private readonly logger = new Logger('PS-Fido-controller');
 
-   /**
+  /**
    * Description: FIDO User Registration
    * @param payload Registration Details
    * @returns Get registered user response
    */
-    @MessagePattern({ cmd: 'generate-registration-options' })
-    async generateRegistrationOption(payload: GenerateRegistrationDto): Promise<object> {
-        return this.fidoService.generateRegistration(payload);
-    }
+  @MessagePattern({ cmd: 'generate-registration-options' })
+  async generateRegistrationOption(payload: GenerateRegistrationDto): Promise<object> {
+    return this.fidoService.generateRegistration(payload);
+  }
 
-   /**
+  /**
    * Description: FIDO User Registration
    * @param payload Verify registration
    * @returns Get verify registration response
    */
-    @MessagePattern({ cmd: 'verify-registration' })
-    verifyRegistration(payload: VerifyRegistrationPayloadDto): Promise<object> {
-        return this.fidoService.verifyRegistration(payload);
-    }
-    /**
+  @MessagePattern({ cmd: 'verify-registration' })
+  verifyRegistration(payload: VerifyRegistrationPayloadDto): Promise<object> {
+    return this.fidoService.verifyRegistration(payload);
+  }
+  /**
    * Description: FIDO User Verification
    * @param payload Authentication details
    * @returns Get authentication response
    */
-    @MessagePattern({ cmd: 'generate-authentication-options' })
-    generateAuthenticationOption(payload: GenerateAuthentication): Promise<object> {
-        const { userName } = payload;
-        return this.fidoService.generateAuthenticationOption(userName);
-    }
-    /**
+  @MessagePattern({ cmd: 'generate-authentication-options' })
+  generateAuthenticationOption(payload: GenerateAuthentication): Promise<object> {
+    const { userName } = payload;
+    return this.fidoService.generateAuthenticationOption(userName);
+  }
+  /**
    * Description: FIDO User Verification
    * @param payload Verify authentication details
    * @returns Get verify authentication details response
    */
-    @MessagePattern({ cmd: 'verify-authentication' })
-    verifyAuthentication(payload: VerifyAuthenticationPayloadDto): Promise<object> {
-        return this.fidoService.verifyAuthentication(payload);
-    }
-    /**
+  @MessagePattern({ cmd: 'verify-authentication' })
+  verifyAuthentication(payload: VerifyAuthenticationPayloadDto): Promise<object> {
+    return this.fidoService.verifyAuthentication(payload);
+  }
+  /**
    * Description: FIDO User update
    * @param payload User Details
    * @returns Get updated user detail response
    */
-    @MessagePattern({ cmd: 'update-user' })
-    updateUser(payload: UpdateFidoUserDetailsDto): Promise<string> {
-        return this.fidoService.updateUser(payload);
-    }
-    /**
+  @MessagePattern({ cmd: 'update-user' })
+  updateUser(payload: UpdateFidoUserPayloadDto): Promise<string> {
+    const { updateFidoUserDetailsDto, credentialId, actorEmail } = payload;
+    return this.fidoService.updateUser({ ...updateFidoUserDetailsDto, credentialId, actorEmail });
+  }
+  /**
    * Description: fetch FIDO user details
    * @param payload User name
-   * 
+   *
    */
-    @MessagePattern({ cmd: 'fetch-fido-user-details' })
-    fetchFidoUserDetails(payload: UserNameDto):Promise<object> {
-        return this.fidoService.fetchFidoUserDetails(payload.email);
-    }
+  @MessagePattern({ cmd: 'fetch-fido-user-details' })
+  fetchFidoUserDetails(payload: UserNameDto): Promise<object> {
+    return this.fidoService.fetchFidoUserDetails(payload.email);
+  }
 
-    /**
+  /**
    * Description: delete FIDO user details
    * @param payload credentialId
-   * 
+   *
    */
-    @MessagePattern({ cmd: 'delete-fido-user-device' })
-    deleteFidoUserDevice(payload: credentialDto):Promise<string>  {
-        return this.fidoService.deleteFidoUserDevice(payload);
-    }
+  @MessagePattern({ cmd: 'delete-fido-user-device' })
+  deleteFidoUserDevice(payload: credentialDto): Promise<string> {
+    return this.fidoService.deleteFidoUserDevice(payload);
+  }
 
-    /**
+  /**
    * Description: update FIDO user details
    * @param payload credentialId and deviceName
-   * 
+   *
    */
-    @MessagePattern({ cmd: 'update-fido-user-device-name' })
-    updateFidoUserDeviceName(payload: updateDeviceDto):Promise<string>  {
-        return this.fidoService.updateFidoUserDeviceName(payload);
-    }
+  @MessagePattern({ cmd: 'update-fido-user-device-name' })
+  updateFidoUserDeviceName(payload: updateDeviceDto): Promise<string> {
+    return this.fidoService.updateFidoUserDeviceName(payload);
+  }
 }

--- a/apps/user/src/fido/fido.service.spec.ts
+++ b/apps/user/src/fido/fido.service.spec.ts
@@ -64,4 +64,22 @@ describe('FidoService passkey device ownership', () => {
     ).rejects.toBeDefined();
     expect(userDevicesRepository.updateDeviceByCredentialId).not.toHaveBeenCalled();
   });
+
+  it('does not rename a credential owned by another user', async () => {
+    fidoUserRepository.checkFidoUserExist.mockResolvedValue({ id: 'actor-id' });
+    userDevicesRepository.checkUserDeviceByCredentialId.mockResolvedValue({
+      id: 'device-id',
+      userId: 'other-user-id',
+      deletedAt: null
+    });
+
+    await expect(
+      service.updateFidoUserDeviceName({
+        credentialId: 'credential-id',
+        deviceName: 'new name',
+        actorEmail: 'actor@example.com'
+      })
+    ).rejects.toBeDefined();
+    expect(userDevicesRepository.updateUserDeviceByCredentialId).not.toHaveBeenCalled();
+  });
 });

--- a/apps/user/src/fido/fido.service.spec.ts
+++ b/apps/user/src/fido/fido.service.spec.ts
@@ -1,5 +1,6 @@
 jest.mock('../user.service', () => ({ UserService: jest.fn() }));
 
+import { ForbiddenException } from '@nestjs/common';
 import { FidoService } from './fido.service';
 
 describe('FidoService passkey device ownership', () => {
@@ -23,8 +24,15 @@ describe('FidoService passkey device ownership', () => {
 
   beforeEach(() => jest.clearAllMocks());
 
+  const mockAuthenticatedActor = (): void => {
+    async function resolveActor(email: string): Promise<{ id: string } | undefined> {
+      return 'actor@example.com' === email ? { id: 'actor-id' } : undefined;
+    }
+    fidoUserRepository.checkFidoUserExist.mockImplementation(resolveActor);
+  };
+
   it('does not delete a credential owned by another user', async () => {
-    fidoUserRepository.checkFidoUserExist.mockResolvedValue({ id: 'actor-id' });
+    mockAuthenticatedActor();
     userDevicesRepository.checkUserDeviceByCredentialId.mockResolvedValue({
       id: 'device-id',
       userId: 'other-user-id',
@@ -33,12 +41,12 @@ describe('FidoService passkey device ownership', () => {
 
     await expect(
       service.deleteFidoUserDevice({ credentialId: 'credential-id', actorEmail: 'actor@example.com' })
-    ).rejects.toBeDefined();
+    ).rejects.toEqual(expect.objectContaining({ error: expect.any(ForbiddenException) }));
     expect(userDevicesRepository.deleteUserDeviceByCredentialId).not.toHaveBeenCalled();
   });
 
   it('deletes a credential owned by the authenticated user', async () => {
-    fidoUserRepository.checkFidoUserExist.mockResolvedValue({ id: 'actor-id' });
+    mockAuthenticatedActor();
     userDevicesRepository.checkUserDeviceByCredentialId.mockResolvedValue({
       id: 'device-id',
       userId: 'actor-id',
@@ -49,10 +57,11 @@ describe('FidoService passkey device ownership', () => {
     await expect(
       service.deleteFidoUserDevice({ credentialId: 'credential-id', actorEmail: 'actor@example.com' })
     ).resolves.toBe('Device deleted successfully');
+    expect(userDevicesRepository.deleteUserDeviceByCredentialId).toHaveBeenCalledWith('credential-id');
   });
 
   it('does not update a credential owned by another user', async () => {
-    fidoUserRepository.checkFidoUserExist.mockResolvedValue({ id: 'actor-id' });
+    mockAuthenticatedActor();
     userDevicesRepository.checkUserDeviceByCredentialId.mockResolvedValue({
       id: 'device-id',
       userId: 'other-user-id',
@@ -61,12 +70,12 @@ describe('FidoService passkey device ownership', () => {
 
     await expect(
       service.updateUser({ credentialId: 'credential-id', actorEmail: 'actor@example.com' } as never)
-    ).rejects.toBeDefined();
+    ).rejects.toEqual(expect.objectContaining({ error: expect.any(ForbiddenException) }));
     expect(userDevicesRepository.updateDeviceByCredentialId).not.toHaveBeenCalled();
   });
 
   it('does not rename a credential owned by another user', async () => {
-    fidoUserRepository.checkFidoUserExist.mockResolvedValue({ id: 'actor-id' });
+    mockAuthenticatedActor();
     userDevicesRepository.checkUserDeviceByCredentialId.mockResolvedValue({
       id: 'device-id',
       userId: 'other-user-id',
@@ -79,7 +88,7 @@ describe('FidoService passkey device ownership', () => {
         deviceName: 'new name',
         actorEmail: 'actor@example.com'
       })
-    ).rejects.toBeDefined();
+    ).rejects.toEqual(expect.objectContaining({ error: expect.any(ForbiddenException) }));
     expect(userDevicesRepository.updateUserDeviceByCredentialId).not.toHaveBeenCalled();
   });
 });

--- a/apps/user/src/fido/fido.service.spec.ts
+++ b/apps/user/src/fido/fido.service.spec.ts
@@ -1,0 +1,51 @@
+jest.mock('../user.service', () => ({ UserService: jest.fn() }));
+
+import { FidoService } from './fido.service';
+
+describe('FidoService passkey device ownership', () => {
+  const fidoUserRepository = {
+    checkFidoUserExist: jest.fn()
+  };
+  const userDevicesRepository = {
+    checkUserDeviceByCredentialId: jest.fn(),
+    deleteUserDeviceByCredentialId: jest.fn(),
+    updateUserDeviceByCredentialId: jest.fn()
+  };
+  const service = new FidoService(
+    fidoUserRepository as never,
+    userDevicesRepository as never,
+    {} as never,
+    {} as never,
+    {} as never
+  );
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does not delete a credential owned by another user', async () => {
+    fidoUserRepository.checkFidoUserExist.mockResolvedValue({ id: 'actor-id' });
+    userDevicesRepository.checkUserDeviceByCredentialId.mockResolvedValue({
+      id: 'device-id',
+      userId: 'other-user-id',
+      deletedAt: null
+    });
+
+    await expect(
+      service.deleteFidoUserDevice({ credentialId: 'credential-id', actorEmail: 'actor@example.com' })
+    ).rejects.toBeDefined();
+    expect(userDevicesRepository.deleteUserDeviceByCredentialId).not.toHaveBeenCalled();
+  });
+
+  it('deletes a credential owned by the authenticated user', async () => {
+    fidoUserRepository.checkFidoUserExist.mockResolvedValue({ id: 'actor-id' });
+    userDevicesRepository.checkUserDeviceByCredentialId.mockResolvedValue({
+      id: 'device-id',
+      userId: 'actor-id',
+      deletedAt: null
+    });
+    userDevicesRepository.deleteUserDeviceByCredentialId.mockResolvedValue({ count: 1 });
+
+    await expect(
+      service.deleteFidoUserDevice({ credentialId: 'credential-id', actorEmail: 'actor@example.com' })
+    ).resolves.toBe('Device deleted successfully');
+  });
+});

--- a/apps/user/src/fido/fido.service.spec.ts
+++ b/apps/user/src/fido/fido.service.spec.ts
@@ -9,7 +9,9 @@ describe('FidoService passkey device ownership', () => {
   const userDevicesRepository = {
     checkUserDeviceByCredentialId: jest.fn(),
     deleteUserDeviceByCredentialId: jest.fn(),
-    updateUserDeviceByCredentialId: jest.fn()
+    updateUserDeviceByCredentialId: jest.fn(),
+    updateDeviceByCredentialId: jest.fn(),
+    addCredentialIdAndNameById: jest.fn()
   };
   const service = new FidoService(
     fidoUserRepository as never,
@@ -47,5 +49,19 @@ describe('FidoService passkey device ownership', () => {
     await expect(
       service.deleteFidoUserDevice({ credentialId: 'credential-id', actorEmail: 'actor@example.com' })
     ).resolves.toBe('Device deleted successfully');
+  });
+
+  it('does not update a credential owned by another user', async () => {
+    fidoUserRepository.checkFidoUserExist.mockResolvedValue({ id: 'actor-id' });
+    userDevicesRepository.checkUserDeviceByCredentialId.mockResolvedValue({
+      id: 'device-id',
+      userId: 'other-user-id',
+      deletedAt: null
+    });
+
+    await expect(
+      service.updateUser({ credentialId: 'credential-id', actorEmail: 'actor@example.com' } as never)
+    ).rejects.toBeDefined();
+    expect(userDevicesRepository.updateDeviceByCredentialId).not.toHaveBeenCalled();
   });
 });

--- a/apps/user/src/fido/fido.service.spec.ts
+++ b/apps/user/src/fido/fido.service.spec.ts
@@ -5,7 +5,8 @@ import { FidoService } from './fido.service';
 
 describe('FidoService passkey device ownership', () => {
   const fidoUserRepository = {
-    checkFidoUserExist: jest.fn()
+    checkFidoUserExist: jest.fn(),
+    getUserDetails: jest.fn()
   };
   const userDevicesRepository = {
     checkUserDeviceByCredentialId: jest.fn(),
@@ -28,7 +29,7 @@ describe('FidoService passkey device ownership', () => {
     async function resolveActor(email: string): Promise<{ id: string } | undefined> {
       return 'actor@example.com' === email ? { id: 'actor-id' } : undefined;
     }
-    fidoUserRepository.checkFidoUserExist.mockImplementation(resolveActor);
+    fidoUserRepository.getUserDetails.mockImplementation(resolveActor);
   };
 
   it('does not delete a credential owned by another user', async () => {
@@ -40,7 +41,7 @@ describe('FidoService passkey device ownership', () => {
     });
 
     await expect(
-      service.deleteFidoUserDevice({ credentialId: 'credential-id', actorEmail: 'actor@example.com' })
+      service.deleteFidoUserDevice({ credentialId: 'Y3JlZGVudGlhbC1pZA', actorEmail: 'actor@example.com' })
     ).rejects.toEqual(expect.objectContaining({ error: expect.any(ForbiddenException) }));
     expect(userDevicesRepository.deleteUserDeviceByCredentialId).not.toHaveBeenCalled();
   });
@@ -55,9 +56,9 @@ describe('FidoService passkey device ownership', () => {
     userDevicesRepository.deleteUserDeviceByCredentialId.mockResolvedValue({ count: 1 });
 
     await expect(
-      service.deleteFidoUserDevice({ credentialId: 'credential-id', actorEmail: 'actor@example.com' })
+      service.deleteFidoUserDevice({ credentialId: 'Y3JlZGVudGlhbC1pZA', actorEmail: 'actor@example.com' })
     ).resolves.toBe('Device deleted successfully');
-    expect(userDevicesRepository.deleteUserDeviceByCredentialId).toHaveBeenCalledWith('credential-id');
+    expect(userDevicesRepository.deleteUserDeviceByCredentialId).toHaveBeenCalledWith('Y3JlZGVudGlhbC1pZA');
   });
 
   it('does not update a credential owned by another user', async () => {
@@ -69,7 +70,7 @@ describe('FidoService passkey device ownership', () => {
     });
 
     await expect(
-      service.updateUser({ credentialId: 'credential-id', actorEmail: 'actor@example.com' } as never)
+      service.updateUser({ credentialId: 'Y3JlZGVudGlhbC1pZA', actorEmail: 'actor@example.com' } as never)
     ).rejects.toEqual(expect.objectContaining({ error: expect.any(ForbiddenException) }));
     expect(userDevicesRepository.updateDeviceByCredentialId).not.toHaveBeenCalled();
   });
@@ -84,7 +85,7 @@ describe('FidoService passkey device ownership', () => {
 
     await expect(
       service.updateFidoUserDeviceName({
-        credentialId: 'credential-id',
+        credentialId: 'Y3JlZGVudGlhbC1pZA',
         deviceName: 'new name',
         actorEmail: 'actor@example.com'
       })

--- a/apps/user/src/fido/fido.service.spec.ts
+++ b/apps/user/src/fido/fido.service.spec.ts
@@ -92,4 +92,32 @@ describe('FidoService passkey device ownership', () => {
     ).rejects.toEqual(expect.objectContaining({ error: expect.any(ForbiddenException) }));
     expect(userDevicesRepository.updateUserDeviceByCredentialId).not.toHaveBeenCalled();
   });
+
+  it('rejects a missing device without deleting it', async () => {
+    mockAuthenticatedActor();
+    userDevicesRepository.checkUserDeviceByCredentialId.mockResolvedValue(null);
+
+    await expect(
+      service.deleteFidoUserDevice({ credentialId: 'Y3JlZGVudGlhbC1pZA', actorEmail: 'actor@example.com' })
+    ).rejects.toEqual(expect.objectContaining({ error: expect.any(ForbiddenException) }));
+    expect(userDevicesRepository.deleteUserDeviceByCredentialId).not.toHaveBeenCalled();
+  });
+
+  it('rejects a deleted device without renaming it', async () => {
+    mockAuthenticatedActor();
+    userDevicesRepository.checkUserDeviceByCredentialId.mockResolvedValue({
+      id: 'device-id',
+      userId: 'actor-id',
+      deletedAt: new Date()
+    });
+
+    await expect(
+      service.updateFidoUserDeviceName({
+        credentialId: 'Y3JlZGVudGlhbC1pZA',
+        deviceName: 'new name',
+        actorEmail: 'actor@example.com'
+      })
+    ).rejects.toEqual(expect.objectContaining({ error: expect.any(ForbiddenException) }));
+    expect(userDevicesRepository.updateUserDeviceByCredentialId).not.toHaveBeenCalled();
+  });
 });

--- a/apps/user/src/fido/fido.service.ts
+++ b/apps/user/src/fido/fido.service.ts
@@ -276,11 +276,19 @@ export class FidoService {
   }
 
   private normalizeCredentialId(credentialId: string): string {
-    if ('string' !== typeof credentialId || !/^[A-Za-z0-9+/_-]+={0,2}$/.test(credentialId)) {
+    if ('string' !== typeof credentialId) {
       throw new BadRequestException('Invalid passkey credential ID');
     }
 
-    const unpaddedCredentialId = credentialId.replace(/=+$/, '');
+    let endIndex = credentialId.length;
+    while (0 < endIndex && '=' === credentialId.charAt(endIndex - 1)) {
+      endIndex -= 1;
+    }
+    const unpaddedCredentialId = credentialId.slice(0, endIndex);
+    if (!/^[A-Za-z0-9+/_-]+$/.test(unpaddedCredentialId)) {
+      throw new BadRequestException('Invalid passkey credential ID');
+    }
+
     if (1 === unpaddedCredentialId.length % 4) {
       throw new BadRequestException('Invalid passkey credential ID');
     }

--- a/apps/user/src/fido/fido.service.ts
+++ b/apps/user/src/fido/fido.service.ts
@@ -1,246 +1,283 @@
-import { BadRequestException, Injectable, Logger, NotFoundException, InternalServerErrorException } from '@nestjs/common'; //InternalServerErrorException
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  InternalServerErrorException
+} from '@nestjs/common'; //InternalServerErrorException
 import { CommonService } from '@credebl/common';
 import { ResponseMessages } from '@credebl/common/response-messages';
 import { RpcException } from '@nestjs/microservices';
 import { FidoUserRepository } from '../../repositories/fido-user.repository';
-import { GenerateRegistrationDto, VerifyRegistrationPayloadDto, VerifyAuthenticationPayloadDto, UpdateFidoUserDetailsDto, credentialDto, updateDeviceDto } from './dtos/fido-user.dto';
+import {
+  GenerateRegistrationDto,
+  VerifyRegistrationPayloadDto,
+  VerifyAuthenticationPayloadDto,
+  UpdateFidoUserDetailsDto,
+  credentialDto,
+  updateDeviceDto
+} from './dtos/fido-user.dto';
 import { UserDevicesRepository } from '../../repositories/user-device.repository';
 import { PrismaService } from '@credebl/prisma-service';
 import { LoginUserDto } from 'apps/user/dtos/login-user.dto';
 import { UserService } from '../user.service';
 
+interface PasskeyDeviceOwnership {
+  id: string;
+  userId: string | null;
+  deletedAt: Date | null;
+}
+
 @Injectable()
 export class FidoService {
-    private readonly logger = new Logger('PS-Fido-Service');
-    constructor(
-        private readonly fidoUserRepository: FidoUserRepository,
-        private readonly userDevicesRepository: UserDevicesRepository,
-        private readonly commonService: CommonService,
-        private readonly userService: UserService,
-        private readonly prisma: PrismaService
-    ) { }
-    async generateRegistration(payload: GenerateRegistrationDto): Promise<object> {
-        try {
-            const { email, deviceFlag } = payload;
-            const fidoUser = await this.fidoUserRepository.checkFidoUserExist(email.toLowerCase());
-            if (!fidoUser && !fidoUser.id) {  
-                throw new NotFoundException(ResponseMessages.user.error.notFound); 
-            }
+  private readonly logger = new Logger('PS-Fido-Service');
+  constructor(
+    private readonly fidoUserRepository: FidoUserRepository,
+    private readonly userDevicesRepository: UserDevicesRepository,
+    private readonly commonService: CommonService,
+    private readonly userService: UserService,
+    private readonly prisma: PrismaService
+  ) {}
+  async generateRegistration(payload: GenerateRegistrationDto): Promise<object> {
+    try {
+      const { email, deviceFlag } = payload;
+      const fidoUser = await this.fidoUserRepository.checkFidoUserExist(email.toLowerCase());
+      if (!fidoUser && !fidoUser.id) {
+        throw new NotFoundException(ResponseMessages.user.error.notFound);
+      }
 
-            if (!fidoUser || true === deviceFlag || false === deviceFlag) {
-                const generatedOption = await this.generateRegistrationOption(email.toLowerCase());
-                return generatedOption;
-            } else if (!fidoUser.isFidoVerified) {
-                const generatedOption = await this.updateUserRegistrationOption(email.toLowerCase());
-                return generatedOption;
-            } else {
-                throw new BadRequestException(ResponseMessages.fido.error.exists);
-            }
-        } catch (error) {
-            this.logger.error(`Error in generate registration option:::${error}`);
-            throw new RpcException(error.response);
+      if (!fidoUser || true === deviceFlag || false === deviceFlag) {
+        const generatedOption = await this.generateRegistrationOption(email.toLowerCase());
+        return generatedOption;
+      } else if (!fidoUser.isFidoVerified) {
+        const generatedOption = await this.updateUserRegistrationOption(email.toLowerCase());
+        return generatedOption;
+      } else {
+        throw new BadRequestException(ResponseMessages.fido.error.exists);
+      }
+    } catch (error) {
+      this.logger.error(`Error in generate registration option:::${error}`);
+      throw new RpcException(error.response);
+    }
+  }
+
+  generateRegistrationOption(email: string): Promise<object> {
+    const url = `${process.env.FIDO_API_ENDPOINT}/generate-registration-options/?userName=${email.toLowerCase()}`;
+    return this.commonService
+      .httpGet(url, { headers: { 'Content-Type': 'application/json' } })
+      .then(async (response) => {
+        const { user } = response;
+        const updateUser = await this.fidoUserRepository.updateUserDetails(email.toLowerCase(), [
+          { fidoUserId: user.id },
+          { username: user.name }
+        ]);
+        if (updateUser.fidoUserId === user.id) {
+          return response;
+        } else {
+          throw new InternalServerErrorException(ResponseMessages.fido.error.generateRegistration);
         }
-    }
+      });
+  }
 
-    generateRegistrationOption(email: string): Promise<object> {
-        const url = `${process.env.FIDO_API_ENDPOINT}/generate-registration-options/?userName=${email.toLowerCase()}`;
-        return this.commonService
-            .httpGet(url, { headers: { 'Content-Type': 'application/json' } })
+  updateUserRegistrationOption(email: string): Promise<object> {
+    const url = `${process.env.FIDO_API_ENDPOINT}/generate-registration-options/?userName=${email.toLowerCase()}`;
+    return this.commonService
+      .httpGet(url, { headers: { 'Content-Type': 'application/json' } })
+      .then(async (response) => {
+        const { user } = response;
+        await this.fidoUserRepository.updateUserDetails(email.toLowerCase(), [
+          { fidoUserId: user.id },
+          { isFidoVerified: false }
+        ]);
+        return response;
+      });
+  }
+
+  async verifyRegistration(verifyRegistrationDto: VerifyRegistrationPayloadDto): Promise<object> {
+    try {
+      const { verifyRegistrationDetails, email } = verifyRegistrationDto;
+      const url = `${process.env.FIDO_API_ENDPOINT}/verify-registration`;
+      const payload = JSON.stringify(verifyRegistrationDetails);
+      const response = await this.commonService.httpPost(url, payload, {
+        headers: { 'Content-Type': 'application/json' }
+      });
+      if (response?.verified && email.toLowerCase()) {
+        await this.fidoUserRepository.updateUserDetails(email.toLowerCase(), [{ isFidoVerified: true }]);
+        const credentialID = response.newDevice.credentialID.replace(/=*$/, '');
+        response.newDevice.credentialID = credentialID;
+        const getUser = await this.fidoUserRepository.checkFidoUserExist(email.toLowerCase());
+        await this.userDevicesRepository.createMultiDevice(response?.newDevice, getUser.id);
+        return response;
+      } else {
+        throw new InternalServerErrorException(ResponseMessages.fido.error.verification);
+      }
+    } catch (error) {
+      this.logger.error(`Error in verify registration option:::${error}`);
+      throw new RpcException(error);
+    }
+  }
+
+  async generateAuthenticationOption(email: string): Promise<object> {
+    try {
+      const fidoUser = await this.fidoUserRepository.checkFidoUserExist(email?.toLowerCase());
+      if (fidoUser && fidoUser.id) {
+        const fidoMultiDevice = await this.userDevicesRepository.getfidoMultiDevice(fidoUser.id);
+        const credentialIds = [];
+        if (fidoMultiDevice) {
+          for (const iterator of fidoMultiDevice) {
+            credentialIds.push(iterator.devices['credentialID']);
+          }
+        } else {
+          throw new BadRequestException(ResponseMessages.fido.error.deviceNotFound);
+        }
+        const url = `${process.env.FIDO_API_ENDPOINT}/generate-authentication-options`;
+        return await this.commonService
+          .httpPost(url, credentialIds, { headers: { 'Content-Type': 'application/json' } })
+          .then(async (response) => response);
+      } else {
+        throw new BadRequestException(ResponseMessages.fido.error.invalidCredentials);
+      }
+    } catch (error) {
+      this.logger.error(`Error in generate authentication option:::${JSON.stringify(error)}`);
+      throw new RpcException(error.response);
+    }
+  }
+
+  async verifyAuthentication(verifyAuthenticationDto: VerifyAuthenticationPayloadDto): Promise<object> {
+    try {
+      const { verifyAuthenticationDetails, email } = verifyAuthenticationDto;
+      const fidoUser = await this.fidoUserRepository.checkFidoUserExist(email.toLowerCase());
+      const fidoMultiDevice = await this.userDevicesRepository.getfidoMultiDeviceDetails(fidoUser.id);
+      const url = `${process.env.FIDO_API_ENDPOINT}/verify-authentication`;
+      const payload = {
+        verifyAuthenticationDetails: JSON.stringify(verifyAuthenticationDetails),
+        devices: fidoMultiDevice
+      };
+
+      const credentialIdChars = {
+        '-': '+',
+        _: '/'
+      };
+
+      const verifyAuthenticationId = verifyAuthenticationDetails.id.replace(
+        /[-_]/g,
+        (replaceCredentialId) => credentialIdChars[replaceCredentialId]
+      );
+      const credentialId = `${verifyAuthenticationId}`;
+      const getUserDevice = await this.userDevicesRepository.checkUserDeviceByCredentialId(credentialId);
+      if (getUserDevice) {
+        const loginCounter = getUserDevice?.authCounter + 1;
+        if (!payload.devices) {
+          throw new BadRequestException(ResponseMessages.fido.error.deviceNotFound);
+        } else {
+          return await this.commonService
+            .httpPost(url, payload, { headers: { 'Content-Type': 'application/json' } })
             .then(async (response) => {
-                const { user } = response;
-                const updateUser = await this.fidoUserRepository.updateUserDetails(email.toLowerCase(), [
-                    {fidoUserId:user.id},
-                    {username:user.name}
-                ]);
-                if (updateUser.fidoUserId === user.id) {
-                    return response;
-                } else {
-                    throw new InternalServerErrorException(ResponseMessages.fido.error.generateRegistration);
-                }
-            });
-    }
-
-    updateUserRegistrationOption(email: string): Promise<object> {
-        const url = `${process.env.FIDO_API_ENDPOINT}/generate-registration-options/?userName=${email.toLowerCase()}`;
-        return this.commonService
-            .httpGet(url, { headers: { 'Content-Type': 'application/json' } })
-            .then(async (response) => {
-                const { user } = response;
-                 await this.fidoUserRepository.updateUserDetails(email.toLowerCase(), [
-                    {fidoUserId:user.id},
-                    {isFidoVerified:false}
-                ]);
-                return response;
-            });
-    }
-
-    async verifyRegistration(verifyRegistrationDto: VerifyRegistrationPayloadDto): Promise<object> {
-        try {
-            const { verifyRegistrationDetails, email } = verifyRegistrationDto;
-            const url = `${process.env.FIDO_API_ENDPOINT}/verify-registration`;
-            const payload = JSON.stringify(verifyRegistrationDetails);
-            const response = await this.commonService.httpPost(url, payload, {
-                headers: { 'Content-Type': 'application/json' }
-              });
-              if (response?.verified && email.toLowerCase()) {
-                await this.fidoUserRepository.updateUserDetails(email.toLowerCase(), [{isFidoVerified:true}]);
-                const credentialID = response.newDevice.credentialID.replace(/=*$/, '');
-                response.newDevice.credentialID = credentialID;
-                const getUser = await this.fidoUserRepository.checkFidoUserExist(email.toLowerCase());
-                await this.userDevicesRepository.createMultiDevice(response?.newDevice, getUser.id);
-                return response;
+              if (true === response.verified) {
+                await this.userDevicesRepository.updateFidoAuthCounter(credentialId, loginCounter);
+                const userDetails: LoginUserDto = {
+                  email,
+                  isPasskey: response.verified
+                };
+                const authDetails = await this.userService.login(userDetails);
+                return authDetails;
               } else {
-                throw new InternalServerErrorException(ResponseMessages.fido.error.verification);
-            }
-        } catch (error) {
-            this.logger.error(`Error in verify registration option:::${error}`);
-            throw new RpcException(error);
+                throw new BadRequestException(ResponseMessages.fido.error.deviceNotFound);
+              }
+            });
         }
+      } else {
+        throw new InternalServerErrorException(ResponseMessages.fido.error.deviceNotFound);
+      }
+    } catch (error) {
+      this.logger.error(`Error in verify authentication:::${error}`);
+      throw new RpcException(ResponseMessages.fido.error.deviceNotFound);
+    }
+  }
+
+  async updateUser(updateFidoUserDetailsDto: UpdateFidoUserDetailsDto): Promise<string> {
+    try {
+      const updateFidoUserDetails = JSON.stringify(updateFidoUserDetailsDto);
+      const updateFidoUser = await this.userDevicesRepository.updateDeviceByCredentialId(
+        updateFidoUserDetailsDto.credentialId
+      );
+
+      if (updateFidoUser[0].id) {
+        await this.userDevicesRepository.addCredentialIdAndNameById(updateFidoUser[0].id, updateFidoUserDetails);
+      }
+      if (updateFidoUser[0].id) {
+        return 'User updated.';
+      } else {
+        throw new InternalServerErrorException(ResponseMessages.fido.error.updateFidoUser);
+      }
+    } catch (error) {
+      this.logger.error(`Error in update user details:::${error}`);
+      throw new RpcException(error);
+    }
+  }
+
+  async fetchFidoUserDetails(email: string): Promise<object> {
+    try {
+      const fidoUser = await this.fidoUserRepository.checkFidoUserExist(email.toLowerCase());
+      if (!fidoUser) {
+        throw new NotFoundException(ResponseMessages.user.error.notFound);
+      }
+      const multiDevice = await this.userDevicesRepository.fidoMultiDevice(fidoUser.id);
+      if (multiDevice) {
+        return multiDevice;
+      } else {
+        throw new RpcException(Error);
+      }
+    } catch (error) {
+      this.logger.error(`Error in fetching the user details:::${error}`);
+      throw new RpcException(error);
+    }
+  }
+
+  async deleteFidoUserDevice(payload: credentialDto): Promise<string> {
+    try {
+      const { credentialId, actorEmail } = payload;
+      await this.assertDeviceOwnership(credentialId, actorEmail);
+      const deleteUserDevice = await this.userDevicesRepository.deleteUserDeviceByCredentialId(credentialId);
+      if (1 === deleteUserDevice.count) {
+        return 'Device deleted successfully';
+      } else {
+        return 'Not deleting this device kindly verify';
+      }
+    } catch (error) {
+      this.logger.error(`Error in delete user device :::${error}`);
+      throw new RpcException(error);
+    }
+  }
+
+  async updateFidoUserDeviceName(payload: updateDeviceDto): Promise<string> {
+    try {
+      const { credentialId, deviceName, actorEmail } = payload;
+      const getUserDevice = await this.assertDeviceOwnership(credentialId, actorEmail);
+      const updateUserDevice = await this.userDevicesRepository.updateUserDeviceByCredentialId(
+        getUserDevice.id,
+        deviceName
+      );
+      if (1 === updateUserDevice.count) {
+        return 'Device name updated successfully.';
+      } else {
+        return 'Device name has not been changed.';
+      }
+    } catch (error) {
+      this.logger.error(`Error in delete user device :::${error}`);
+      throw new RpcException(error);
+    }
+  }
+
+  private async assertDeviceOwnership(credentialId: string, actorEmail: string): Promise<PasskeyDeviceOwnership> {
+    const actor = await this.fidoUserRepository.checkFidoUserExist(actorEmail.toLowerCase());
+    const device = await this.userDevicesRepository.checkUserDeviceByCredentialId(credentialId);
+
+    if (!device || device.userId !== actor.id || device.deletedAt) {
+      throw new ForbiddenException('Passkey device can only be managed by its owner');
     }
 
-    async generateAuthenticationOption(email: string): Promise<object> {
-        try {
-            const fidoUser = await this.fidoUserRepository.checkFidoUserExist(email?.toLowerCase());
-            if (fidoUser && fidoUser.id) {
-                const fidoMultiDevice = await this.userDevicesRepository.getfidoMultiDevice(fidoUser.id);
-                const credentialIds = [];
-                if (fidoMultiDevice) {
-                    for (const iterator of fidoMultiDevice) {
-                        credentialIds.push(iterator.devices['credentialID']);
-                    }
-                } else {
-                    throw new BadRequestException(ResponseMessages.fido.error.deviceNotFound);
-                }
-                const url = `${process.env.FIDO_API_ENDPOINT}/generate-authentication-options`;
-                return await this.commonService
-                    .httpPost(url, credentialIds, { headers: { 'Content-Type': 'application/json' } })
-                    .then(async (response) => response);
-            } else {
-                throw new BadRequestException(ResponseMessages.fido.error.invalidCredentials);
-            }
-        } catch (error) {
-            this.logger.error(`Error in generate authentication option:::${JSON.stringify(error)}`);
-            throw new RpcException(error.response);
-        }
-    }
-
-    async verifyAuthentication(verifyAuthenticationDto: VerifyAuthenticationPayloadDto): Promise<object> {
-        try {
-            const { verifyAuthenticationDetails, email } = verifyAuthenticationDto;
-            const fidoUser = await this.fidoUserRepository.checkFidoUserExist(email.toLowerCase());
-            const fidoMultiDevice = await this.userDevicesRepository.getfidoMultiDeviceDetails(fidoUser.id);
-            const url = `${process.env.FIDO_API_ENDPOINT}/verify-authentication`;
-            const payload = { verifyAuthenticationDetails: JSON.stringify(verifyAuthenticationDetails), devices: fidoMultiDevice };
-
-            const credentialIdChars = {
-                '-': '+',
-                '_': '/'
-            };
-
-            const verifyAuthenticationId = verifyAuthenticationDetails.id.replace(/[-_]/g, replaceCredentialId => credentialIdChars[replaceCredentialId]);
-            const credentialId = `${verifyAuthenticationId}`;
-            const getUserDevice =  await this.userDevicesRepository.checkUserDeviceByCredentialId(credentialId);
-            if (getUserDevice) {
-                const loginCounter = getUserDevice?.authCounter + 1;
-                if (!payload.devices) {
-                    throw new BadRequestException(ResponseMessages.fido.error.deviceNotFound);
-                } else {
-                    return await this.commonService
-                        .httpPost(url, payload, { headers: { 'Content-Type': 'application/json' } })
-                        .then(async (response) => {
-                            if (true === response.verified) {
-                                await this.userDevicesRepository.updateFidoAuthCounter(credentialId, loginCounter);
-                                const userDetails: LoginUserDto = {
-                                    email,
-                                    isPasskey: response.verified
-                                };
-                                const authDetails = await this.userService.login(userDetails);
-                                return authDetails;
-                            } else {
-                                throw new BadRequestException(ResponseMessages.fido.error.deviceNotFound);
-                            }
-                            
-                        });
-                }
-            } else {
-                throw new InternalServerErrorException(ResponseMessages.fido.error.deviceNotFound);
-            }
-        } catch (error) {
-
-            this.logger.error(`Error in verify authentication:::${error}`);
-            throw new RpcException(ResponseMessages.fido.error.deviceNotFound);
-        }
-    }
-
-    async updateUser(updateFidoUserDetailsDto: UpdateFidoUserDetailsDto): Promise<string> {
-        try {
-
-            const updateFidoUserDetails = JSON.stringify(updateFidoUserDetailsDto);
-            const updateFidoUser = await this.userDevicesRepository.updateDeviceByCredentialId(updateFidoUserDetailsDto.credentialId);
-
-            if (updateFidoUser[0].id) {
-             await this.userDevicesRepository.addCredentialIdAndNameById(updateFidoUser[0].id, updateFidoUserDetails);
-             
-            }
-            if (updateFidoUser[0].id) {
-                return 'User updated.';
-            } else {
-                throw new InternalServerErrorException(ResponseMessages.fido.error.updateFidoUser);
-            }
-
-        } catch (error) {
-            this.logger.error(`Error in update user details:::${error}`);
-            throw new RpcException(error);
-        }
-    }
-
-    async fetchFidoUserDetails(email: string): Promise<object> {
-        try {
-            const fidoUser = await this.fidoUserRepository.checkFidoUserExist(email.toLowerCase());
-            if (!fidoUser) {
-                throw new NotFoundException(ResponseMessages.user.error.notFound);    
-            }
-            const multiDevice = await this.userDevicesRepository.fidoMultiDevice(fidoUser.id);
-            if (multiDevice) {
-                return multiDevice;
-            } else {
-                throw new RpcException(Error);
-            }
-        } catch (error) {
-            this.logger.error(`Error in fetching the user details:::${error}`);
-            throw new RpcException(error);
-        }
-    }
-
-    async deleteFidoUserDevice(payload: credentialDto): Promise<string> {
-        try {
-            const { credentialId } = payload;
-            await this.userDevicesRepository.checkUserDeviceByCredentialId(credentialId);
-            const deleteUserDevice = await this.userDevicesRepository.deleteUserDeviceByCredentialId(credentialId);
-            if (1 === deleteUserDevice.count) {
-                return 'Device deleted successfully';
-            } else {
-                return 'Not deleting this device kindly verify';
-            }
-        } catch (error) {
-            this.logger.error(`Error in delete user device :::${error}`);
-            throw new RpcException(error);
-        }
-    }
-
-    async updateFidoUserDeviceName(payload: updateDeviceDto): Promise<string> {
-        try {
-            const { credentialId, deviceName } = payload;
-            const getUserDevice = await this.userDevicesRepository.checkUserDeviceByCredentialId(credentialId);
-            const updateUserDevice = await this.userDevicesRepository.updateUserDeviceByCredentialId(getUserDevice.id, deviceName);
-            if (1 === updateUserDevice.count) {
-                return 'Device name updated successfully.';
-            } else {
-                return 'Device name has not been changed.';
-            }
-        } catch (error) {
-            this.logger.error(`Error in delete user device :::${error}`);
-            throw new RpcException(error);
-        }
-    }
+    return device;
+  }
 }

--- a/apps/user/src/fido/fido.service.ts
+++ b/apps/user/src/fido/fido.service.ts
@@ -104,10 +104,10 @@ export class FidoService {
       });
       if (response?.verified && email.toLowerCase()) {
         await this.fidoUserRepository.updateUserDetails(email.toLowerCase(), [{ isFidoVerified: true }]);
-        const credentialID = response.newDevice.credentialID.replace(/=*$/, '');
+        const credentialID = this.normalizeCredentialId(response.newDevice.credentialID);
         response.newDevice.credentialID = credentialID;
         const getUser = await this.fidoUserRepository.checkFidoUserExist(email.toLowerCase());
-        await this.userDevicesRepository.createMultiDevice(response?.newDevice, getUser.id);
+        await this.userDevicesRepository.createMultiDevice(response?.newDevice, getUser.id, credentialID);
         return response;
       } else {
         throw new InternalServerErrorException(ResponseMessages.fido.error.verification);
@@ -155,16 +155,7 @@ export class FidoService {
         devices: fidoMultiDevice
       };
 
-      const credentialIdChars = {
-        '-': '+',
-        _: '/'
-      };
-
-      const verifyAuthenticationId = verifyAuthenticationDetails.id.replace(
-        /[-_]/g,
-        (replaceCredentialId) => credentialIdChars[replaceCredentialId]
-      );
-      const credentialId = `${verifyAuthenticationId}`;
+      const credentialId = this.normalizeCredentialId(verifyAuthenticationDetails.id);
       const getUserDevice = await this.userDevicesRepository.checkUserDeviceByCredentialId(credentialId);
       if (getUserDevice) {
         const loginCounter = getUserDevice?.authCounter + 1;
@@ -199,9 +190,10 @@ export class FidoService {
   async updateUser(updateFidoUserDetailsDto: UpdateFidoUserDetailsDto & { actorEmail: string }): Promise<string> {
     try {
       const { actorEmail, credentialId, ...userDetails } = updateFidoUserDetailsDto;
-      const ownedDevice = await this.assertDeviceOwnership(credentialId, actorEmail);
-      const updateFidoUserDetails = JSON.stringify({ ...userDetails, credentialId });
-      const updateFidoUser = await this.userDevicesRepository.updateDeviceByCredentialId(credentialId);
+      const normalizedCredentialId = this.normalizeCredentialId(credentialId);
+      const ownedDevice = await this.assertDeviceOwnership(normalizedCredentialId, actorEmail);
+      const updateFidoUserDetails = JSON.stringify({ ...userDetails, credentialId: normalizedCredentialId });
+      const updateFidoUser = await this.userDevicesRepository.updateDeviceByCredentialId(normalizedCredentialId);
 
       if (updateFidoUser[0]?.id && updateFidoUser[0].id === ownedDevice.id) {
         await this.userDevicesRepository.addCredentialIdAndNameById(ownedDevice.id, updateFidoUserDetails);
@@ -238,8 +230,9 @@ export class FidoService {
   async deleteFidoUserDevice(payload: credentialDto): Promise<string> {
     try {
       const { credentialId, actorEmail } = payload;
-      await this.assertDeviceOwnership(credentialId, actorEmail);
-      const deleteUserDevice = await this.userDevicesRepository.deleteUserDeviceByCredentialId(credentialId);
+      const normalizedCredentialId = this.normalizeCredentialId(credentialId);
+      await this.assertDeviceOwnership(normalizedCredentialId, actorEmail);
+      const deleteUserDevice = await this.userDevicesRepository.deleteUserDeviceByCredentialId(normalizedCredentialId);
       if (1 === deleteUserDevice.count) {
         return 'Device deleted successfully';
       } else {
@@ -254,7 +247,8 @@ export class FidoService {
   async updateFidoUserDeviceName(payload: updateDeviceDto): Promise<string> {
     try {
       const { credentialId, deviceName, actorEmail } = payload;
-      const getUserDevice = await this.assertDeviceOwnership(credentialId, actorEmail);
+      const normalizedCredentialId = this.normalizeCredentialId(credentialId);
+      const getUserDevice = await this.assertDeviceOwnership(normalizedCredentialId, actorEmail);
       const updateUserDevice = await this.userDevicesRepository.updateUserDeviceByCredentialId(
         getUserDevice.id,
         deviceName
@@ -271,13 +265,26 @@ export class FidoService {
   }
 
   private async assertDeviceOwnership(credentialId: string, actorEmail: string): Promise<PasskeyDeviceOwnership> {
-    const actor = await this.fidoUserRepository.checkFidoUserExist(actorEmail.toLowerCase());
+    const actor = await this.fidoUserRepository.getUserDetails(actorEmail.toLowerCase());
     const device = await this.userDevicesRepository.checkUserDeviceByCredentialId(credentialId);
 
-    if (!device || device.userId !== actor.id || device.deletedAt) {
+    if (!actor || !device || device.userId !== actor.id || device.deletedAt) {
       throw new ForbiddenException('Passkey device can only be managed by its owner');
     }
 
     return device;
+  }
+
+  private normalizeCredentialId(credentialId: string): string {
+    if ('string' !== typeof credentialId || !/^[A-Za-z0-9+/_-]+={0,2}$/.test(credentialId)) {
+      throw new BadRequestException('Invalid passkey credential ID');
+    }
+
+    const unpaddedCredentialId = credentialId.replace(/=+$/, '');
+    if (1 === unpaddedCredentialId.length % 4) {
+      throw new BadRequestException('Invalid passkey credential ID');
+    }
+
+    return unpaddedCredentialId.replace(/\+/g, '-').replace(/\//g, '_');
   }
 }

--- a/apps/user/src/fido/fido.service.ts
+++ b/apps/user/src/fido/fido.service.ts
@@ -196,17 +196,17 @@ export class FidoService {
     }
   }
 
-  async updateUser(updateFidoUserDetailsDto: UpdateFidoUserDetailsDto): Promise<string> {
+  async updateUser(updateFidoUserDetailsDto: UpdateFidoUserDetailsDto & { actorEmail: string }): Promise<string> {
     try {
-      const updateFidoUserDetails = JSON.stringify(updateFidoUserDetailsDto);
-      const updateFidoUser = await this.userDevicesRepository.updateDeviceByCredentialId(
-        updateFidoUserDetailsDto.credentialId
-      );
+      const { actorEmail, credentialId, ...userDetails } = updateFidoUserDetailsDto;
+      const ownedDevice = await this.assertDeviceOwnership(credentialId, actorEmail);
+      const updateFidoUserDetails = JSON.stringify({ ...userDetails, credentialId });
+      const updateFidoUser = await this.userDevicesRepository.updateDeviceByCredentialId(credentialId);
 
-      if (updateFidoUser[0].id) {
-        await this.userDevicesRepository.addCredentialIdAndNameById(updateFidoUser[0].id, updateFidoUserDetails);
+      if (updateFidoUser[0]?.id && updateFidoUser[0].id === ownedDevice.id) {
+        await this.userDevicesRepository.addCredentialIdAndNameById(ownedDevice.id, updateFidoUserDetails);
       }
-      if (updateFidoUser[0].id) {
+      if (updateFidoUser[0]?.id) {
         return 'User updated.';
       } else {
         throw new InternalServerErrorException(ResponseMessages.fido.error.updateFidoUser);

--- a/libs/prisma-service/prisma/migrations/20260806090000_harden_status_list_allocation/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260806090000_harden_status_list_allocation/migration.sql
@@ -1,3 +1,27 @@
+-- Fail before enforcing new invariants if legacy rows would violate them. We cannot
+-- safely choose a credential allocation to delete because that changes revocation semantics.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "issued_oid4vc_credentials"
+    GROUP BY "listId", "index"
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Cannot create status-list slot uniqueness constraint: duplicate credential allocations exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "status_list_allocation"
+    WHERE "isActive" = true
+    GROUP BY "orgId", "issuerDid"
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Cannot create active status-list constraint: multiple active lists exist for a tenant and issuer';
+  END IF;
+END $$;
+
 -- Prevent two service replicas from persisting the same status-list slot.
 CREATE UNIQUE INDEX "issued_oid4vc_credentials_listId_index_key"
 ON "issued_oid4vc_credentials"("listId", "index");

--- a/libs/prisma-service/prisma/migrations/20260806090000_harden_status_list_allocation/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260806090000_harden_status_list_allocation/migration.sql
@@ -1,0 +1,9 @@
+-- Prevent two service replicas from persisting the same status-list slot.
+CREATE UNIQUE INDEX "issued_oid4vc_credentials_listId_index_key"
+ON "issued_oid4vc_credentials"("listId", "index");
+
+-- There must be at most one active list for a tenant/issuer pair. Prisma does
+-- not currently model partial indexes, so this invariant lives in SQL.
+CREATE UNIQUE INDEX "status_list_allocation_one_active_per_issuer_key"
+ON "status_list_allocation"("orgId", "issuerDid")
+WHERE "isActive" = true;

--- a/libs/prisma-service/prisma/migrations/20260806090000_harden_status_list_allocation/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260806090000_harden_status_list_allocation/migration.sql
@@ -1,3 +1,10 @@
+BEGIN;
+
+-- Keep duplicate validation and index creation in the same write-exclusion window.
+-- ACCESS SHARE would permit concurrent inserts, so it is not sufficient here.
+LOCK TABLE "issued_oid4vc_credentials" IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE "status_list_allocation" IN SHARE ROW EXCLUSIVE MODE;
+
 -- Fail before enforcing new invariants if legacy rows would violate them. We cannot
 -- safely choose a credential allocation to delete because that changes revocation semantics.
 DO $$
@@ -31,3 +38,5 @@ ON "issued_oid4vc_credentials"("listId", "index");
 CREATE UNIQUE INDEX "status_list_allocation_one_active_per_issuer_key"
 ON "status_list_allocation"("orgId", "issuerDid")
 WHERE "isActive" = true;
+
+COMMIT;

--- a/libs/prisma-service/prisma/migrations/20260806090000_harden_status_list_allocation/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260806090000_harden_status_list_allocation/migration.sql
@@ -34,7 +34,8 @@ CREATE UNIQUE INDEX "issued_oid4vc_credentials_listId_index_key"
 ON "issued_oid4vc_credentials"("listId", "index");
 
 -- There must be at most one active list for a tenant/issuer pair. Prisma does
--- not currently model partial indexes, so this invariant lives in SQL.
+-- not currently model partial indexes, so this invariant lives in SQL. Keep this index in future
+-- Prisma migrations; prisma migrate dev can otherwise propose dropping it from the shadow-schema diff.
 CREATE UNIQUE INDEX "status_list_allocation_one_active_per_issuer_key"
 ON "status_list_allocation"("orgId", "issuerDid")
 WHERE "isActive" = true;

--- a/libs/prisma-service/prisma/migrations/20260822000000_backfill_user_devices_credential_id/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260822000000_backfill_user_devices_credential_id/migration.sql
@@ -1,0 +1,55 @@
+-- Backfill user_devices.credentialId from the credential embedded in the devices JSON.
+--
+-- Devices registered before credentialId was persisted at registration time only carried
+-- the value inside devices->>'credentialID'. Ownership checks and authentication lookups
+-- query the column, so those legacy rows are unreachable for rename/delete and passkey login.
+--
+-- Legacy JSON values were stored padding-stripped but not URL-safe encoded. They are
+-- normalized to unpadded base64url (strip '=' padding, '+' -> '-', '/' -> '_') to match
+-- what FidoService.normalizeCredentialId produces before every lookup.
+
+BEGIN;
+
+-- The credentialId column has a unique constraint. Fail with a clear message instead of
+-- letting the UPDATE hit a constraint violation mid-migration.
+DO $$
+DECLARE
+  collision_count int;
+BEGIN
+  SELECT COUNT(*)
+  INTO collision_count
+  FROM (
+    SELECT translate(regexp_replace("devices"->>'credentialID', '=+$', ''), '+/', '-_') AS normalized_id
+    FROM "user_devices"
+    WHERE "devices" ? 'credentialID'
+      AND "devices"->>'credentialID' IS NOT NULL
+    GROUP BY 1
+    HAVING COUNT(*) > 1
+  ) collisions;
+
+  IF collision_count > 0 THEN
+    RAISE EXCEPTION 'Cannot backfill user_devices.credentialId: % device(s) collide on the same credential ID after normalization; resolve manually first', collision_count;
+  END IF;
+END $$;
+
+WITH normalized AS (
+  SELECT
+    "id",
+    translate(regexp_replace("devices"->>'credentialID', '=+$', ''), '+/', '-_') AS normalized_id
+  FROM "user_devices"
+  WHERE "devices" ? 'credentialID'
+    AND "devices"->>'credentialID' IS NOT NULL
+)
+UPDATE "user_devices" ud
+SET
+  "credentialId" = n.normalized_id,
+  "devices" = jsonb_set(ud."devices", '{credentialID}', to_jsonb(n.normalized_id)),
+  "lastChangedDateTime" = now()
+FROM normalized n
+WHERE ud."id" = n."id"
+  AND (
+    ud."credentialId" IS DISTINCT FROM n.normalized_id
+    OR ud."devices"->>'credentialID' IS DISTINCT FROM n.normalized_id
+  );
+
+COMMIT;

--- a/libs/prisma-service/prisma/migrations/20260822000000_backfill_user_devices_credential_id/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260822000000_backfill_user_devices_credential_id/migration.sql
@@ -7,49 +7,33 @@
 -- Legacy JSON values were stored padding-stripped but not URL-safe encoded. They are
 -- normalized to unpadded base64url (strip '=' padding, '+' -> '-', '/' -> '_') to match
 -- what FidoService.normalizeCredentialId produces before every lookup.
+--
+-- The UPDATE below is a single statement, so it is atomic: if two devices collide on the
+-- same normalized credential ID (the column has a unique constraint), the exception
+-- handler replaces the constraint error with an actionable message and nothing is written.
 
 BEGIN;
 
--- The credentialId column has a unique constraint. Fail with a clear message instead of
--- letting the UPDATE hit a constraint violation mid-migration.
 DO $$
-DECLARE
-  collision_count int;
 BEGIN
-  SELECT COUNT(*)
-  INTO collision_count
-  FROM (
-    SELECT translate(regexp_replace("devices"->>'credentialID', '=+$', ''), '+/', '-_') AS normalized_id
+  WITH normalized AS (
+    SELECT
+      "id",
+      translate(regexp_replace("devices"->>'credentialID', '=+$', ''), '+/', '-_') AS normalized_id
     FROM "user_devices"
-    WHERE "devices" ? 'credentialID'
-      AND "devices"->>'credentialID' IS NOT NULL
-    GROUP BY 1
-    HAVING COUNT(*) > 1
-  ) collisions;
+    WHERE "devices"->>'credentialID' IS NOT NULL
+  )
+  UPDATE "user_devices" ud
+  SET
+    "credentialId" = n.normalized_id,
+    "devices" = jsonb_set(ud."devices", '{credentialID}', to_jsonb(n.normalized_id)),
+    "lastChangedDateTime" = now()
+  FROM normalized n
+  WHERE ud."id" = n."id";
 
-  IF collision_count > 0 THEN
-    RAISE EXCEPTION 'Cannot backfill user_devices.credentialId: % device(s) collide on the same credential ID after normalization; resolve manually first', collision_count;
-  END IF;
+EXCEPTION
+  WHEN unique_violation THEN
+    RAISE EXCEPTION 'Cannot backfill user_devices.credentialId: devices collide on the same credential ID after normalization; resolve manually first';
 END $$;
-
-WITH normalized AS (
-  SELECT
-    "id",
-    translate(regexp_replace("devices"->>'credentialID', '=+$', ''), '+/', '-_') AS normalized_id
-  FROM "user_devices"
-  WHERE "devices" ? 'credentialID'
-    AND "devices"->>'credentialID' IS NOT NULL
-)
-UPDATE "user_devices" ud
-SET
-  "credentialId" = n.normalized_id,
-  "devices" = jsonb_set(ud."devices", '{credentialID}', to_jsonb(n.normalized_id)),
-  "lastChangedDateTime" = now()
-FROM normalized n
-WHERE ud."id" = n."id"
-  AND (
-    ud."credentialId" IS DISTINCT FROM n.normalized_id
-    OR ud."devices"->>'credentialID' IS DISTINCT FROM n.normalized_id
-  );
 
 COMMIT;

--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -120,49 +120,49 @@ model user_org_roles {
 }
 
 model organisation {
-  id                    String                  @id @default(uuid()) @db.Uuid
-  createDateTime        DateTime                @default(now()) @db.Timestamptz(6)
-  createdBy             String                  @db.Uuid
-  lastChangedDateTime   DateTime                @default(now()) @db.Timestamptz(6)
-  lastChangedBy         String                  @db.Uuid
-  name                  String?                 @db.VarChar(500)
-  description           String?                 @db.VarChar(500)
-  orgSlug               String?                 @unique
-  logoUrl               String?
-  website               String?                 @db.VarChar
-  publicProfile         Boolean                 @default(false)
-  idpId                 String?                 @db.VarChar(500)
-  clientId              String?                 @db.VarChar(500)
-  clientSecret          String?                 @db.VarChar(500)
-  registrationNumber    String?                 @db.VarChar(100)
-  appLaunchDetails      Json?
-  countryId             Int?
-  countries             countries?              @relation(fields: [countryId], references: [id])
-  stateId               Int?
-  states                states?                 @relation(fields: [stateId], references: [id])
-  cityId                Int?
-  cities                cities?                 @relation(fields: [cityId], references: [id])
-  connections            connections[]
-  credentials            credentials[]
-  org_agents             org_agents[]
-  orgInvitations         org_invitations[]
-  presentations          presentations[]
-  schema                 schema[]
-  user_activities        user_activity[]
-  userOrgRoles           user_org_roles[]
-  agent_invitations      agent_invitations[]
-  credential_definition  credential_definition[]
-  file_upload            file_upload[]
-  oid4vc_credentials     oid4vc_credentials[]
-  oid4vp_presentations   oid4vp_presentations[]
-  verification_templates verification_templates[]
-  intent_templates       intent_templates[]
-  intent_notices         intent_notices[]
-  ecosystemOrgs          ecosystem_orgs[]
-  ecosystem_invitations  ecosystem_invitations[]
-  status_list_allocations status_list_allocation[]
+  id                        String                      @id @default(uuid()) @db.Uuid
+  createDateTime            DateTime                    @default(now()) @db.Timestamptz(6)
+  createdBy                 String                      @db.Uuid
+  lastChangedDateTime       DateTime                    @default(now()) @db.Timestamptz(6)
+  lastChangedBy             String                      @db.Uuid
+  name                      String?                     @db.VarChar(500)
+  description               String?                     @db.VarChar(500)
+  orgSlug                   String?                     @unique
+  logoUrl                   String?
+  website                   String?                     @db.VarChar
+  publicProfile             Boolean                     @default(false)
+  idpId                     String?                     @db.VarChar(500)
+  clientId                  String?                     @db.VarChar(500)
+  clientSecret              String?                     @db.VarChar(500)
+  registrationNumber        String?                     @db.VarChar(100)
+  appLaunchDetails          Json?
+  countryId                 Int?
+  countries                 countries?                  @relation(fields: [countryId], references: [id])
+  stateId                   Int?
+  states                    states?                     @relation(fields: [stateId], references: [id])
+  cityId                    Int?
+  cities                    cities?                     @relation(fields: [cityId], references: [id])
+  connections               connections[]
+  credentials               credentials[]
+  org_agents                org_agents[]
+  orgInvitations            org_invitations[]
+  presentations             presentations[]
+  schema                    schema[]
+  user_activities           user_activity[]
+  userOrgRoles              user_org_roles[]
+  agent_invitations         agent_invitations[]
+  credential_definition     credential_definition[]
+  file_upload               file_upload[]
+  oid4vc_credentials        oid4vc_credentials[]
+  oid4vp_presentations      oid4vp_presentations[]
+  verification_templates    verification_templates[]
+  intent_templates          intent_templates[]
+  intent_notices            intent_notices[]
+  ecosystemOrgs             ecosystem_orgs[]
+  ecosystem_invitations     ecosystem_invitations[]
+  status_list_allocations   status_list_allocation[]
   issued_oid4vc_credentials issued_oid4vc_credentials[]
-  oidc_issuer oidc_issuer[] 
+  oidc_issuer               oidc_issuer[]
 }
 
 model org_invitations {
@@ -597,11 +597,10 @@ model oidc_issuer {
   templates                   credential_templates[]
   batchCredentialIssuanceSize Int                    @default(0)
 
-  orgId     String?  @db.Uuid
-  isPrimary Boolean  @default(false)
+  orgId     String? @db.Uuid
+  isPrimary Boolean @default(false)
 
   organisation organisation? @relation(fields: [orgId], references: [id])
-
 
   @@index([orgAgentId])
 }
@@ -619,7 +618,7 @@ model oid4vc_credentials {
   lastChangedBy              String   @db.Uuid
   credentialConfigurationIds String[]
   issuedCredentials          String[]
-  publicIssuerId              String
+  publicIssuerId             String
 
   organisation organisation @relation(fields: [orgId], references: [id], onDelete: Restrict)
 
@@ -627,32 +626,32 @@ model oid4vc_credentials {
 }
 
 model oid4vp_presentations {
-  id                    String   @id @default(uuid()) @db.Uuid
-  orgId                 String   @db.Uuid
-  verificationSessionId String   @unique
+  id                    String       @id @default(uuid()) @db.Uuid
+  orgId                 String       @db.Uuid
+  verificationSessionId String       @unique
   presentationId        String
   state                 String
   contextCorrelationId  String
-  createdBy             String   @db.Uuid
-  createDateTime        DateTime @default(now()) @db.Timestamptz(6)
-  lastChangedDateTime   DateTime @default(now()) @db.Timestamptz(6)
-  lastChangedBy         String   @db.Uuid
-  publicVerifierId    String
-  organisation organisation @relation(fields: [orgId], references: [id])
+  createdBy             String       @db.Uuid
+  createDateTime        DateTime     @default(now()) @db.Timestamptz(6)
+  lastChangedDateTime   DateTime     @default(now()) @db.Timestamptz(6)
+  lastChangedBy         String       @db.Uuid
+  publicVerifierId      String
+  organisation          organisation @relation(fields: [orgId], references: [id])
 }
 
 model status_list_allocation {
-  id              String   @id @default(uuid()) @db.Uuid
-  orgId           String   @db.Uuid
-  issuerDid       String
-  listId          String   @unique @db.Uuid
-  listSize        Int      @default(131072)
-  allocatedCount  Int      @default(0)
-  bitmap          Bytes
-  isActive        Boolean  @default(true)
-  createDateTime  DateTime @default(now()) @db.Timestamptz(6)
-  updatedAt       DateTime @updatedAt
-  organisation    organisation @relation(fields: [orgId], references: [id])
+  id             String       @id @default(uuid()) @db.Uuid
+  orgId          String       @db.Uuid
+  issuerDid      String
+  listId         String       @unique @db.Uuid
+  listSize       Int          @default(131072)
+  allocatedCount Int          @default(0)
+  bitmap         Bytes
+  isActive       Boolean      @default(true)
+  createDateTime DateTime     @default(now()) @db.Timestamptz(6)
+  updatedAt      DateTime     @updatedAt
+  organisation   organisation @relation(fields: [orgId], references: [id])
 
   @@index([orgId, isActive])
 }
@@ -670,6 +669,7 @@ model issued_oid4vc_credentials {
 
   organisation organisation? @relation(fields: [orgId], references: [id], onDelete: Restrict)
 
+  @@unique([listId, index], map: "issued_oid4vc_credentials_listId_index_key")
   @@index([orgId, issuanceSessionId])
 }
 
@@ -692,7 +692,7 @@ model credential_templates {
   issuerId String      @db.Uuid
   issuer   oidc_issuer @relation(fields: [issuerId], references: [id])
 
-  noticeUrl    String?
+  noticeUrl String?
 
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
@@ -712,7 +712,7 @@ model x509_certificates {
   expiry            DateTime
   certificateBase64 String
   isImported        Boolean  @default(false)
-  keyId     String?
+  keyId             String?
 
   createdAt           DateTime @default(now())
   createdBy           String   @db.Uuid
@@ -736,15 +736,15 @@ model oid4vp_verifier {
 }
 
 model verification_templates {
-  id                  String              @id @default(uuid()) @db.Uuid
-  name                String              @db.VarChar(500)
+  id                  String             @id @default(uuid()) @db.Uuid
+  name                String             @db.VarChar(500)
   templateJson        Json
-  orgId               String              @db.Uuid
-  createDateTime      DateTime            @default(now()) @db.Timestamptz(6)
-  createdBy           String              @db.Uuid
-  lastChangedDateTime DateTime            @default(now()) @db.Timestamptz(6)
-  lastChangedBy       String              @db.Uuid
-  organisation        organisation        @relation(fields: [orgId], references: [id])
+  orgId               String             @db.Uuid
+  createDateTime      DateTime           @default(now()) @db.Timestamptz(6)
+  createdBy           String             @db.Uuid
+  lastChangedDateTime DateTime           @default(now()) @db.Timestamptz(6)
+  lastChangedBy       String             @db.Uuid
+  organisation        organisation       @relation(fields: [orgId], references: [id])
   signerOption        SignerOption
   intentTemplates     intent_templates[]
 
@@ -753,28 +753,28 @@ model verification_templates {
 
 model intents {
   id                  String             @id @default(uuid()) @db.Uuid
-  ecosystemId String @db.Uuid
+  ecosystemId         String             @db.Uuid
   name                String             @db.VarChar(500)
   description         String?
   createDateTime      DateTime           @default(now()) @db.Timestamptz(6)
   createdBy           String             @db.Uuid
   lastChangedDateTime DateTime           @default(now()) @db.Timestamptz(6)
   lastChangedBy       String             @db.Uuid
-  ecosystem ecosystem @relation(fields: [ecosystemId], references: [id])
+  ecosystem           ecosystem          @relation(fields: [ecosystemId], references: [id])
   intentTemplates     intent_templates[]
   intentNotices       intent_notices[]
 }
 
 model intent_templates {
   id                  String                 @id @default(uuid()) @db.Uuid
-  orgId               String?                 @db.Uuid
+  orgId               String?                @db.Uuid
   intentId            String                 @db.Uuid
   templateId          String                 @db.Uuid
   createDateTime      DateTime               @default(now()) @db.Timestamptz(6)
   createdBy           String                 @db.Uuid
   lastChangedDateTime DateTime               @default(now()) @db.Timestamptz(6)
   lastChangedBy       String                 @db.Uuid
-  organisation        organisation?           @relation(fields: [orgId], references: [id])
+  organisation        organisation?          @relation(fields: [orgId], references: [id])
   intent              intents                @relation(fields: [intentId], references: [id])
   template            verification_templates @relation(fields: [templateId], references: [id])
 
@@ -814,7 +814,7 @@ model ecosystem {
 
   ecosystemOrgs        ecosystem_orgs[]
   ecosystemInvitations ecosystem_invitations[]
-  intent              intents[]
+  intent               intents[]
   ledgers              Json?
 }
 
@@ -830,29 +830,29 @@ model ecosystem_roles {
 }
 
 model ecosystem_orgs {
-  id                  String    @id @default(uuid()) @db.Uuid
-  orgId               String    @db.Uuid
+  id                  String          @id @default(uuid()) @db.Uuid
+  orgId               String          @db.Uuid
   status              String
   deploymentMode      String?
-  ecosystemId         String    @db.Uuid
-  ecosystemRoleId     String    @db.Uuid
-  createDateTime      DateTime  @default(now()) @db.Timestamptz(6)
-  createdBy           String    @db.Uuid
-  lastChangedDateTime DateTime  @default(now()) @db.Timestamptz(6)
-  lastChangedBy       String    @db.Uuid
-  deletedAt           DateTime? @db.Timestamp(6)
-  userId              String    @db.Uuid
-  ecosystem     ecosystem       @relation(fields: [ecosystemId], references: [id])
-  ecosystemRole ecosystem_roles @relation(fields: [ecosystemRoleId], references: [id])
-  organisation  organisation    @relation(fields: [orgId], references: [id])
-  user          user            @relation(fields:[userId], references: [id])
+  ecosystemId         String          @db.Uuid
+  ecosystemRoleId     String          @db.Uuid
+  createDateTime      DateTime        @default(now()) @db.Timestamptz(6)
+  createdBy           String          @db.Uuid
+  lastChangedDateTime DateTime        @default(now()) @db.Timestamptz(6)
+  lastChangedBy       String          @db.Uuid
+  deletedAt           DateTime?       @db.Timestamp(6)
+  userId              String          @db.Uuid
+  ecosystem           ecosystem       @relation(fields: [ecosystemId], references: [id])
+  ecosystemRole       ecosystem_roles @relation(fields: [ecosystemRoleId], references: [id])
+  organisation        organisation    @relation(fields: [orgId], references: [id])
+  user                user            @relation(fields: [userId], references: [id])
 
   @@unique([orgId, ecosystemId])
 }
 
 model ecosystem_invitations {
   id                  String    @id @default(uuid()) @db.Uuid
-  email               String    
+  email               String
   status              String
   userId              String?   @db.Uuid
   type                String
@@ -864,13 +864,12 @@ model ecosystem_invitations {
   lastChangedBy       String    @db.Uuid
   deletedAt           DateTime? @db.Timestamp(6)
 
-  organisation        organisation? @relation(fields: [invitedOrg], references: [id])
-  ecosystem           ecosystem? @relation(fields: [ecosystemId], references: [id])
-  user                user?      @relation(fields: [userId], references: [id])
+  organisation organisation? @relation(fields: [invitedOrg], references: [id])
+  ecosystem    ecosystem?    @relation(fields: [ecosystemId], references: [id])
+  user         user?         @relation(fields: [userId], references: [id])
 
   @@unique([email, ecosystemId, invitedOrg])
 }
-
 
 model holder_notification {
   id                  String    @id @default(uuid()) @db.Uuid


### PR DESCRIPTION
## What changed

- Restrict JWT issuer and JWKS resolution to trusted issuers configured through `JWT_TRUSTED_ISSUERS` or the Keycloak realm.
- Require JWT authentication for passkey management and enforce authenticated-user ownership for reads, updates, and deletes.
- Serialize status-list allocation and add database constraints/migration to prevent duplicate allocation under concurrency.

## Why

The previous behavior trusted an unverified JWT issuer while selecting JWKS, allowed passkey operations without consistent caller ownership checks, and relied on application-level coordination for status-list uniqueness.

## Impact

Deployments can optionally configure a comma-separated `JWT_TRUSTED_ISSUERS` allowlist. When omitted, the configured Keycloak domain and realm are used. The included migration adds uniqueness safeguards for issued credential slots and active issuer allocations.

## Validation

- Targeted issuer, passkey, and status-list allocation unit tests: 4 suites, 12 assertions.
- Relevant services compiled successfully.
- Prisma schema, ESLint, and whitespace/diff checks passed.

Fixes #1705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable JWT trusted-issuer validation and secure JWKS resolution.
  * Added authenticated ownership checks and actor tracking for passkey operations.
  * Improved passkey credential normalization and status-list allocation safeguards.
  * Added stronger credential-slot uniqueness protections.

* **Bug Fixes**
  * Prevented unauthorized access to other users’ passkeys.
  * Improved handling of concurrent and exhausted status-list allocations.
  * Preserved allocations when credential offers are successfully created.
  * Rejected invalid or unsafe JWT issuer configurations.

* **Tests**
  * Expanded coverage for JWT security, passkey ownership, and status-list allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->