### PR TITLE
fix: refactored openBao and secret-provider logic

### DIFF
--- a/libs/common/src/common.constant.ts
+++ b/libs/common/src/common.constant.ts
@@ -443,11 +443,11 @@ export enum CommonConstants {
   OIDC_VERIFIER_SESSION_RESPONSE_GET_BY_ID = 'get-oid4vp-verifier-session-response-id',
   OIDC_VERIFIER_SESSION_AUTH_RESPONSE_VERIFY = 'verify-oid4vp-verifier-session-auth-response',
 
-  // BAO_STORAGE_PATH
-  CREDEBL_RESEND_API_KEY_PATH = 'secret/data/credebl_resend_api_key',
-  CREDEBL_SMTP_CONFIG_PATH = 'secret/data/credebl_smtp_config',
-  CREDEBL_SENDGRID_API_KEY_PATH = 'secret/data/credebl_sendgrid_api_key',
-  CREDEBL_AWS_KEY_PATH = 'secret/data/credebl_aws_keys',
+  // Secret storage keys (provider-agnostic; each provider resolves these to its backend path)
+  RESEND_API_KEY = 'credebl_resend_api_key',
+  SMTP_CONFIG = 'credebl_smtp_config',
+  SENDGRID_API_KEY = 'credebl_sendgrid_api_key',
+  AWS_KEY = 'credebl_aws_keys',
 
   //X509
   X509_CREATE_CERTIFICATE = 'create-x509-certificate',

--- a/libs/common/src/resend-helper-file.spec.ts
+++ b/libs/common/src/resend-helper-file.spec.ts
@@ -1,5 +1,6 @@
 import { sendWithResend } from './resend-helper-file';
 import { fetchSecrets } from './utils/secretLoader.util';
+import { CommonConstants } from './common.constant';
 
 jest.mock('resend', () => ({
   Resend: jest.fn()
@@ -42,7 +43,7 @@ describe('sendWithResend', () => {
 
     await expect(sendWithResend(emailDto)).resolves.toBe(true);
 
-    expect(mockedFetchSecrets).toHaveBeenCalledWith('secret/data/credebl_resend_api_key');
+    expect(mockedFetchSecrets).toHaveBeenCalledWith(CommonConstants.RESEND_API_KEY);
     expect(MockedResend).toHaveBeenCalledWith('resend-key');
     expect(sendMock).toHaveBeenCalledWith(
       expect.objectContaining({ to: emailDto.emailTo, subject: emailDto.emailSubject })

--- a/libs/common/src/resend-helper-file.ts
+++ b/libs/common/src/resend-helper-file.ts
@@ -6,8 +6,8 @@ import { fetchSecrets } from './utils/secretLoader.util';
 
 export const sendWithResend = async (emailDto: EmailDto): Promise<boolean> => {
   try {
-    const secretPath = CommonConstants.CREDEBL_RESEND_API_KEY_PATH;
-    const secrets = await fetchSecrets(secretPath);
+    const secretKey = CommonConstants.RESEND_API_KEY;
+    const secrets = await fetchSecrets(secretKey);
     const apiKey = secrets.RESEND_API_KEY ?? process.env.RESEND_API_KEY;
 
     if (!apiKey) {

--- a/libs/common/src/send-grid-helper-file.spec.ts
+++ b/libs/common/src/send-grid-helper-file.spec.ts
@@ -1,5 +1,6 @@
 import { sendWithSendGrid } from './send-grid-helper-file';
 import { fetchSecrets } from './utils/secretLoader.util';
+import { CommonConstants } from './common.constant';
 
 jest.mock('@sendgrid/mail', () => ({
   setApiKey: jest.fn(),
@@ -42,7 +43,7 @@ describe('sendWithSendGrid', () => {
 
     await expect(sendWithSendGrid(emailDto)).resolves.toBe(true);
 
-    expect(mockedFetchSecrets).toHaveBeenCalledWith('secret/data/credebl_sendgrid_api_key');
+    expect(mockedFetchSecrets).toHaveBeenCalledWith(CommonConstants.SENDGRID_API_KEY);
     expect(mockedSetApiKey).toHaveBeenCalledWith('sg-key');
     expect(mockedSend).toHaveBeenCalledWith(expect.objectContaining({ to: emailDto.emailTo }));
   });

--- a/libs/common/src/send-grid-helper-file.ts
+++ b/libs/common/src/send-grid-helper-file.ts
@@ -7,8 +7,8 @@ import { fetchSecrets } from './utils/secretLoader.util';
 
 export const sendWithSendGrid = async (EmailDto: EmailDto): Promise<boolean> => {
   try {
-    const secretPath = CommonConstants.CREDEBL_SENDGRID_API_KEY_PATH;
-    const secrets = await fetchSecrets(secretPath);
+    const secretKey = CommonConstants.SENDGRID_API_KEY;
+    const secrets = await fetchSecrets(secretKey);
     const apiKey = secrets.SENDGRID_API_KEY ?? process.env.SENDGRID_API_KEY;
 
     if (!apiKey) {

--- a/libs/common/src/smtp-helper-file.spec.ts
+++ b/libs/common/src/smtp-helper-file.spec.ts
@@ -1,5 +1,6 @@
 import { sendWithSMTP } from './smtp-helper-file';
 import { fetchSecrets } from './utils/secretLoader.util';
+import { CommonConstants } from './common.constant';
 
 jest.mock('nodemailer', () => ({
   createTransport: jest.fn()
@@ -50,7 +51,7 @@ describe('sendWithSMTP', () => {
 
     await expect(sendWithSMTP(emailDto)).resolves.toBe(true);
 
-    expect(mockedFetchSecrets).toHaveBeenCalledWith('secret/data/credebl_smtp_config');
+    expect(mockedFetchSecrets).toHaveBeenCalledWith(CommonConstants.SMTP_CONFIG);
     expect(mockedCreateTransport).toHaveBeenCalledWith(
       expect.objectContaining({
         host: 'smtp.example.com',

--- a/libs/common/src/smtp-helper-file.ts
+++ b/libs/common/src/smtp-helper-file.ts
@@ -7,8 +7,8 @@ import { fetchSecrets } from './utils/secretLoader.util';
 
 export const sendWithSMTP = async (emailDto: EmailDto): Promise<boolean> => {
   try {
-    const secretPath = CommonConstants.CREDEBL_SMTP_CONFIG_PATH;
-    const secrets = await fetchSecrets(secretPath);
+    const secretKey = CommonConstants.SMTP_CONFIG;
+    const secrets = await fetchSecrets(secretKey);
     const smtpHost = secrets.SMTP_HOST ?? process.env.SMTP_HOST;
     const smtpPort = secrets.SMTP_PORT ?? process.env.SMTP_PORT;
     const smtpUser = secrets.SMTP_USER ?? process.env.SMTP_USER;

--- a/libs/common/src/utils/secretLoader.util.spec.ts
+++ b/libs/common/src/utils/secretLoader.util.spec.ts
@@ -1,18 +1,25 @@
-import { fetchSecrets } from './secretLoader.util';
-import { getSecretProvider } from 'libs/config/src/secret-storage/secrets-loader';
+import { CommonConstants } from '../common.constant';
 
 jest.mock('libs/config/src/secret-storage/secrets-loader', () => ({
   getSecretProvider: jest.fn()
 }));
 
-const mockedGetSecretProvider = getSecretProvider as jest.MockedFunction<typeof getSecretProvider>;
-
 describe('fetchSecrets', () => {
   const originalEnv = { ...process.env };
 
+  let fetchSecrets: (secretKey: string) => Promise<Record<string, string>>;
+  let mockedGetSecretProvider: jest.Mock;
+
   beforeEach(() => {
+    jest.resetModules();
     delete process.env.ENABLE_BAO;
     delete process.env.SECRETS_PROVIDER;
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    ({ fetchSecrets } = require('./secretLoader.util'));
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    mockedGetSecretProvider = require('libs/config/src/secret-storage/secrets-loader').getSecretProvider;
+
     jest.clearAllMocks();
   });
 
@@ -23,7 +30,7 @@ describe('fetchSecrets', () => {
   it('returns an empty object when OpenBao is disabled', async () => {
     process.env.ENABLE_BAO = 'false';
 
-    await expect(fetchSecrets('secret/data/credebl_smtp_config')).resolves.toEqual({});
+    await expect(fetchSecrets(CommonConstants.SMTP_CONFIG)).resolves.toEqual({});
     expect(mockedGetSecretProvider).not.toHaveBeenCalled();
   });
 
@@ -31,7 +38,7 @@ describe('fetchSecrets', () => {
     process.env.ENABLE_BAO = 'true';
     delete process.env.SECRETS_PROVIDER;
 
-    await expect(fetchSecrets('secret/data/credebl_smtp_config_2')).resolves.toEqual({});
+    await expect(fetchSecrets(CommonConstants.SMTP_CONFIG)).resolves.toEqual({});
     expect(mockedGetSecretProvider).not.toHaveBeenCalled();
   });
 
@@ -40,47 +47,52 @@ describe('fetchSecrets', () => {
     process.env.SECRETS_PROVIDER = 'consul';
     mockedGetSecretProvider.mockReturnValue(null);
 
-    await expect(fetchSecrets('secret/data/credebl_smtp_config_3')).resolves.toEqual({});
+    await expect(fetchSecrets(CommonConstants.SMTP_CONFIG)).resolves.toEqual({});
     expect(mockedGetSecretProvider).toHaveBeenCalledWith('consul');
   });
 
-  it('fetches the secrets for the requested path via the active provider', async () => {
+  it.each([
+    CommonConstants.RESEND_API_KEY as string,
+    CommonConstants.SMTP_CONFIG as string,
+    CommonConstants.SENDGRID_API_KEY as string,
+    CommonConstants.AWS_KEY as string
+  ])('fetches secrets for %s via the active provider through the secretKey option', async (secretKey: string) => {
     process.env.ENABLE_BAO = 'true';
     process.env.SECRETS_PROVIDER = 'openbao';
     const loadSecrets = jest.fn().mockResolvedValue({ SMTP_HOST: 'smtp.example.com', SMTP_PORT: '587' });
     mockedGetSecretProvider.mockReturnValue({ name: 'OpenBao', loadSecrets });
 
-    await expect(fetchSecrets('secret/data/credebl_smtp_config_4')).resolves.toEqual({
+    await expect(fetchSecrets(secretKey)).resolves.toEqual({
       SMTP_HOST: 'smtp.example.com',
       SMTP_PORT: '587'
     });
 
-    expect(loadSecrets).toHaveBeenCalledWith({ customPath: 'secret/data/credebl_smtp_config_4' });
+    expect(loadSecrets).toHaveBeenCalledWith({ secretKey });
   });
 
-  it('caches the result per path and does not re-invoke the provider', async () => {
+  it('caches the result per secret key and does not re-invoke the provider', async () => {
     process.env.ENABLE_BAO = 'true';
     process.env.SECRETS_PROVIDER = 'openbao';
     const loadSecrets = jest.fn().mockResolvedValue({ RESEND_API_KEY: 'k' });
     mockedGetSecretProvider.mockReturnValue({ name: 'OpenBao', loadSecrets });
 
-    await fetchSecrets('secret/data/credebl_resend_api_key');
-    await fetchSecrets('secret/data/credebl_resend_api_key');
+    await fetchSecrets(CommonConstants.RESEND_API_KEY);
+    await fetchSecrets(CommonConstants.RESEND_API_KEY);
 
     expect(loadSecrets).toHaveBeenCalledTimes(1);
   });
 
-  it('uses an independent cache per secret path', async () => {
+  it('uses an independent cache per secret key', async () => {
     process.env.ENABLE_BAO = 'true';
     process.env.SECRETS_PROVIDER = 'openbao';
     const loadSecrets = jest.fn().mockResolvedValue({ SOME_KEY: 'v' });
     mockedGetSecretProvider.mockReturnValue({ name: 'OpenBao', loadSecrets });
 
-    await fetchSecrets('secret/data/path_a');
-    await fetchSecrets('secret/data/path_b');
+    await fetchSecrets(CommonConstants.SMTP_CONFIG);
+    await fetchSecrets(CommonConstants.RESEND_API_KEY);
 
     expect(loadSecrets).toHaveBeenCalledTimes(2);
-    expect(loadSecrets).toHaveBeenCalledWith({ customPath: 'secret/data/path_a' });
-    expect(loadSecrets).toHaveBeenCalledWith({ customPath: 'secret/data/path_b' });
+    expect(loadSecrets).toHaveBeenCalledWith({ secretKey: CommonConstants.SMTP_CONFIG });
+    expect(loadSecrets).toHaveBeenCalledWith({ secretKey: CommonConstants.RESEND_API_KEY });
   });
 });

--- a/libs/common/src/utils/secretLoader.util.ts
+++ b/libs/common/src/utils/secretLoader.util.ts
@@ -5,14 +5,14 @@ const CACHE_TTL_MS = 10 * 60 * 1000;
 
 const secretCaches = new Map<string, TtlCache<Record<string, string>>>();
 
-export async function fetchSecrets(secretPath: string): Promise<Record<string, string>> {
+export async function fetchSecrets(secretKey: string): Promise<Record<string, string>> {
   if ('true' !== process.env.ENABLE_BAO?.trim()?.toLowerCase()) {
     return {};
   }
-  let cache = secretCaches.get(secretPath);
+  let cache = secretCaches.get(secretKey);
   if (!cache) {
     cache = new TtlCache<Record<string, string>>(CACHE_TTL_MS);
-    secretCaches.set(secretPath, cache);
+    secretCaches.set(secretKey, cache);
   }
   return cache.get(async () => {
     const providerType = process.env.SECRETS_PROVIDER?.trim();
@@ -23,6 +23,6 @@ export async function fetchSecrets(secretPath: string): Promise<Record<string, s
     if (!provider) {
       return {};
     }
-    return provider.loadSecrets({ customPath: secretPath });
+    return provider.loadSecrets({ secretKey });
   });
 }

--- a/libs/config/src/secret-storage/openbao.provider.spec.ts
+++ b/libs/config/src/secret-storage/openbao.provider.spec.ts
@@ -1,3 +1,4 @@
+import { CommonConstants } from '@credebl/common/common.constant';
 import { OpenBaoProvider } from './openbao.provider';
 
 describe('OpenBaoProvider', () => {
@@ -41,6 +42,7 @@ describe('OpenBaoProvider', () => {
 
   it('authenticates with AppRole and fetches secrets from the configured path', async () => {
     fetchMock
+      // eslint-disable-next-line camelcase
       .mockResolvedValueOnce(jsonResponse({ auth: { client_token: 'client-token' } }))
       .mockResolvedValueOnce(jsonResponse({ data: { data: { RESEND_API_KEY: 'resend-key' } } }));
 
@@ -51,6 +53,7 @@ describe('OpenBaoProvider', () => {
       'http://bao:8200/v1/auth/approle/login',
       expect.objectContaining({
         method: 'POST',
+        // eslint-disable-next-line camelcase
         body: JSON.stringify({ role_id: 'role-id', secret_id: 'secret-id' })
       })
     );
@@ -64,18 +67,31 @@ describe('OpenBaoProvider', () => {
     );
   });
 
-  it('fetches from a custom path when one is supplied', async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse({ auth: { client_token: 'client-token' } }))
-      .mockResolvedValueOnce(jsonResponse({ data: { data: { KEY: 'value' } } }));
+  it.each([
+    [CommonConstants.RESEND_API_KEY as string, 'secret/data/credebl_resend_api_key'],
+    [CommonConstants.SMTP_CONFIG as string, 'secret/data/credebl_smtp_config'],
+    [CommonConstants.SENDGRID_API_KEY as string, 'secret/data/credebl_sendgrid_api_key'],
+    [CommonConstants.AWS_KEY as string, 'secret/data/credebl_aws_keys']
+  ])(
+    'fetches %s from its mapped OpenBao path (%s), independent of BAO_SECRET_PATH',
+    async (secretKey: string, expectedPath: string) => {
+      delete process.env.BAO_SECRET_PATH;
+      fetchMock
+        // eslint-disable-next-line camelcase
+        .mockResolvedValueOnce(jsonResponse({ auth: { client_token: 'client-token' } }))
+        .mockResolvedValueOnce(jsonResponse({ data: { data: { KEY: 'value' } } }));
 
-    await provider.loadSecrets({ customPath: 'secret/data/credebl_smtp_config' });
+      await expect(provider.loadSecrets({ secretKey })).resolves.toEqual({ KEY: 'value' });
 
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
-      'http://bao:8200/v1/secret/data/credebl_smtp_config',
-      expect.anything()
+      expect(fetchMock).toHaveBeenNthCalledWith(2, `http://bao:8200/v1/${expectedPath}`, expect.anything());
+    }
+  );
+
+  it('rejects when a secret key has no mapped OpenBao path', async () => {
+    await expect(provider.loadSecrets({ secretKey: 'unknown_key' })).rejects.toThrow(
+      'No OpenBao path mapped for secret key: unknown_key'
     );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('rejects when the AppRole login response is not ok', async () => {
@@ -92,6 +108,7 @@ describe('OpenBaoProvider', () => {
 
   it('rejects when the secrets fetch response is not ok', async () => {
     fetchMock
+      // eslint-disable-next-line camelcase
       .mockResolvedValueOnce(jsonResponse({ auth: { client_token: 'client-token' } }))
       .mockResolvedValueOnce(jsonResponse({}, false, 404));
 
@@ -100,6 +117,7 @@ describe('OpenBaoProvider', () => {
 
   it('rejects when the payload has an unexpected structure', async () => {
     fetchMock
+      // eslint-disable-next-line camelcase
       .mockResolvedValueOnce(jsonResponse({ auth: { client_token: 'client-token' } }))
       .mockResolvedValueOnce(jsonResponse({ data: {} }));
 
@@ -108,6 +126,7 @@ describe('OpenBaoProvider', () => {
 
   it('rejects when the payload data is an array', async () => {
     fetchMock
+      // eslint-disable-next-line camelcase
       .mockResolvedValueOnce(jsonResponse({ auth: { client_token: 'client-token' } }))
       .mockResolvedValueOnce(jsonResponse({ data: { data: [] } }));
 
@@ -122,6 +141,7 @@ describe('OpenBaoProvider', () => {
 
   it('rejects with a timeout error when the secrets fetch is aborted', async () => {
     fetchMock
+      // eslint-disable-next-line camelcase
       .mockResolvedValueOnce(jsonResponse({ auth: { client_token: 'client-token' } }))
       .mockRejectedValueOnce(new DOMException('The operation was aborted.', 'AbortError'));
 

--- a/libs/config/src/secret-storage/openbao.provider.ts
+++ b/libs/config/src/secret-storage/openbao.provider.ts
@@ -17,13 +17,26 @@ export class OpenBaoProvider implements SecretProvider {
   readonly name = 'OpenBao';
   private readonly logger = new Logger(OpenBaoProvider.name);
 
+  private readonly secretPathMap: Record<string, string> = {
+    [CommonConstants.RESEND_API_KEY]: 'secret/data/credebl_resend_api_key',
+    [CommonConstants.SMTP_CONFIG]: 'secret/data/credebl_smtp_config',
+    [CommonConstants.SENDGRID_API_KEY]: 'secret/data/credebl_sendgrid_api_key',
+    [CommonConstants.AWS_KEY]: 'secret/data/credebl_aws_keys'
+  };
+
   isEnabled(): boolean {
     return 'true' === process.env.ENABLE_BAO?.trim()?.toLowerCase();
   }
 
-  async loadSecrets(options?: { customPath?: string }): Promise<Record<string, string>> {
+  async loadSecrets(options?: { secretKey?: string }): Promise<Record<string, string>> {
     const baoUrl = process.env.BAO_URL;
-    const secretPath = options?.customPath || process.env.BAO_SECRET_PATH;
+    let secretPath = process.env.BAO_SECRET_PATH;
+    if (options?.secretKey) {
+      secretPath = this.secretPathMap[options.secretKey];
+      if (!secretPath) {
+        throw new Error(`No OpenBao path mapped for secret key: ${options.secretKey}`);
+      }
+    }
     const roleId = process.env.BAO_ROLE_ID;
     const secretId = process.env.BAO_SECRET_ID;
     if (!baoUrl || !secretPath || !roleId || !secretId) {

--- a/libs/config/src/secret-storage/openbao.provider.ts
+++ b/libs/config/src/secret-storage/openbao.provider.ts
@@ -30,13 +30,7 @@ export class OpenBaoProvider implements SecretProvider {
 
   async loadSecrets(options?: { secretKey?: string }): Promise<Record<string, string>> {
     const baoUrl = process.env.BAO_URL;
-    let secretPath = process.env.BAO_SECRET_PATH;
-    if (options?.secretKey) {
-      secretPath = this.secretPathMap[options.secretKey];
-      if (!secretPath) {
-        throw new Error(`No OpenBao path mapped for secret key: ${options.secretKey}`);
-      }
-    }
+    const secretPath = this.resolveSecretPath(options?.secretKey);
     const roleId = process.env.BAO_ROLE_ID;
     const secretId = process.env.BAO_SECRET_ID;
     if (!baoUrl || !secretPath || !roleId || !secretId) {
@@ -44,67 +38,77 @@ export class OpenBaoProvider implements SecretProvider {
     }
     this.logger.log(`Fetching secrets from ${baoUrl}/v1/${secretPath}`);
     this.logger.log(`Authenticating with AppRole at ${baoUrl}/v1/auth/approle/login`);
-    // --- Authentication ---
-    let authResponse: Response;
-    try {
-      authResponse = await fetchWithTimeout(
-        `${baoUrl}/v1/auth/approle/login`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          // eslint-disable-next-line camelcase
-          body: JSON.stringify({ role_id: roleId, secret_id: secretId })
-        },
-        CommonConstants.OPENBAO_REQUEST_TIMEOUT
-      );
-    } catch (error) {
-      if (error instanceof DOMException && 'AbortError' === error.name) {
-        throw new Error('OpenBao authentication request timed out.');
-      }
-      throw error;
-    }
-    if (!authResponse.ok) {
-      throw new Error(`Authentication failed: Status ${authResponse.status}`);
-    }
 
-    const authData = await authResponse.json();
+    const authData = await this.sendRequest<{ auth?: { client_token?: string } }>(
+      `${baoUrl}/v1/auth/approle/login`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // eslint-disable-next-line camelcase
+        body: JSON.stringify({ role_id: roleId, secret_id: secretId })
+      },
+      'Authentication failed',
+      'OpenBao authentication request timed out.'
+    );
+
     const baoToken = authData.auth?.client_token;
 
     if (!baoToken) {
       throw new Error('Failed to retrieve client token from OpenBao.');
     }
     this.logger.log(`Fetching secrets from ${baoUrl}/v1/${secretPath}`);
-    // --- Fetch Secrets ---
-    let response: Response;
-    try {
-      response = await fetchWithTimeout(
-        `${baoUrl}/v1/${secretPath}`,
-        {
-          method: 'GET',
-          headers: {
-            'X-Vault-Token': baoToken,
-            'Content-Type': 'application/json'
-          }
-        },
-        CommonConstants.OPENBAO_REQUEST_TIMEOUT
-      );
-    } catch (error) {
-      if (error instanceof DOMException && 'AbortError' === error.name) {
-        throw new Error('OpenBao secrets fetch request timed out.');
-      }
-      throw error;
-    }
-    if (!response.ok) {
-      throw new Error(`Fetch failed: Status ${response.status}`);
-    }
 
-    const result = await response.json();
-    const secrets = result.data?.data;
+    const secretsData = await this.sendRequest<{ data?: { data?: Record<string, string> } }>(
+      `${baoUrl}/v1/${secretPath}`,
+      {
+        method: 'GET',
+        headers: {
+          'X-Vault-Token': baoToken,
+          'Content-Type': 'application/json'
+        }
+      },
+      'Fetch failed',
+      'OpenBao secrets fetch request timed out.'
+    );
+
+    const secrets = secretsData.data?.data;
     this.logger.log('Successfully fetched secrets from OpenBao');
     if (!secrets || 'object' !== typeof secrets || Array.isArray(secrets)) {
       throw new Error('Unexpected secrets payload structure.');
     }
 
     return secrets as Record<string, string>;
+  }
+
+  private resolveSecretPath(secretKey?: string): string | undefined {
+    if (!secretKey) {
+      return process.env.BAO_SECRET_PATH;
+    }
+    const secretPath = this.secretPathMap[secretKey];
+    if (!secretPath) {
+      throw new Error(`No OpenBao path mapped for secret key: ${secretKey}`);
+    }
+    return secretPath;
+  }
+
+  private async sendRequest<T>(
+    url: string,
+    init: RequestInit,
+    statusErrorMessage: string,
+    timeoutErrorMessage: string
+  ): Promise<T> {
+    try {
+      const response = await fetchWithTimeout(url, init, CommonConstants.OPENBAO_REQUEST_TIMEOUT);
+      if (!response.ok) {
+        throw new Error(`${statusErrorMessage}: Status ${response.status}`);
+      }
+      const body = await response.json();
+      return body as T;
+    } catch (error) {
+      if (error instanceof DOMException && 'AbortError' === error.name) {
+        throw new Error(timeoutErrorMessage);
+      }
+      throw error;
+    }
   }
 }

--- a/libs/config/src/secret-storage/secret-provider.interface.ts
+++ b/libs/config/src/secret-storage/secret-provider.interface.ts
@@ -9,5 +9,5 @@ export interface SecretProvider {
    * as a flat key-value object of strings.
    * * @returns A promise resolving to Record<string, string>
    */
-  loadSecrets(options?: Record<string, unknown>): Promise<Record<string, string>>;
+  loadSecrets(options?: { secretKey?: string }): Promise<Record<string, string>>;
 }

--- a/libs/storage/src/providers/s3-storage.provider.spec.ts
+++ b/libs/storage/src/providers/s3-storage.provider.spec.ts
@@ -1,5 +1,6 @@
 import { S3StorageService } from './s3-storage.provider';
 import { fetchSecrets } from '@credebl/common/utils/secretLoader.util';
+import { CommonConstants } from '@credebl/common/common.constant';
 
 jest.mock('aws-sdk', () => ({
   S3: jest.fn()
@@ -43,7 +44,7 @@ describe('S3StorageService', () => {
 
     await (service as unknown as { getS3Client: ClientGetter }).getS3Client();
 
-    expect(mockedFetchSecrets).toHaveBeenCalledWith('secret/data/credebl_aws_keys');
+    expect(mockedFetchSecrets).toHaveBeenCalledWith(CommonConstants.AWS_KEY);
     expect(MockedS3).toHaveBeenCalledWith({
       accessKeyId: 'secret-key',
       secretAccessKey: 'secret-secret',

--- a/libs/storage/src/providers/s3-storage.provider.ts
+++ b/libs/storage/src/providers/s3-storage.provider.ts
@@ -7,7 +7,7 @@ import { fetchSecrets } from '@credebl/common/utils/secretLoader.util';
 @Injectable()
 export class S3StorageService extends BaseS3StorageService {
   protected async getS3Client(): Promise<S3> {
-    const secrets = await fetchSecrets(CommonConstants.CREDEBL_AWS_KEY_PATH);
+    const secrets = await fetchSecrets(CommonConstants.AWS_KEY);
     return new S3({
       accessKeyId: secrets.AWS_ACCESS_KEY ?? process.env.AWS_ACCESS_KEY,
       secretAccessKey: secrets.AWS_SECRET_KEY ?? process.env.AWS_SECRET_KEY,
@@ -16,7 +16,7 @@ export class S3StorageService extends BaseS3StorageService {
   }
 
   protected async getPublicS3Client(): Promise<S3> {
-    const secrets = await fetchSecrets(CommonConstants.CREDEBL_AWS_KEY_PATH);
+    const secrets = await fetchSecrets(CommonConstants.AWS_KEY);
     return new S3({
       accessKeyId: secrets.AWS_PUBLIC_ACCESS_KEY ?? process.env.AWS_PUBLIC_ACCESS_KEY,
       secretAccessKey: secrets.AWS_PUBLIC_SECRET_KEY ?? process.env.AWS_PUBLIC_SECRET_KEY,
@@ -25,7 +25,7 @@ export class S3StorageService extends BaseS3StorageService {
   }
 
   protected async getStoreObjectS3Client(): Promise<S3> {
-    const secrets = await fetchSecrets(CommonConstants.CREDEBL_AWS_KEY_PATH);
+    const secrets = await fetchSecrets(CommonConstants.AWS_KEY);
     return new S3({
       accessKeyId: secrets.AWS_S3_STOREOBJECT_ACCESS_KEY ?? process.env.AWS_S3_STOREOBJECT_ACCESS_KEY,
       secretAccessKey: secrets.AWS_S3_STOREOBJECT_SECRET_KEY ?? process.env.AWS_S3_STOREOBJECT_SECRET_KEY,


### PR DESCRIPTION
#What?
- Replaced CREDEBL_*_PATH constants that held OpenBao KV v2 paths (secret/data/...) with bare, provider-agnostic keys
- Path resolution now lives inside the provider

#Why?
- Secret paths are a provider concern. This decouples the app from OpenBao — future providers map the same keys to their own format.
- Behavior Unchanged - OpenBao still receives the same full paths. No env changes needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized secret retrieval for email, SMTP, SendGrid, AWS, and storage integrations.
  * Added predefined OpenBao mappings for supported secret keys.
  * Unsupported secret keys are now rejected clearly.

* **Bug Fixes**
  * Improved consistency when loading secrets across supported integrations.
  * Enhanced request handling for authentication and secret retrieval.

* **Tests**
  * Expanded coverage for mappings, caching, supported keys, and invalid key handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->