### PR TITLE
revert: uuid 14.0.0 bump (#1658) — ESM-only breaks jest test suite

### DIFF
--- a/libs/common/package.json
+++ b/libs/common/package.json
@@ -28,7 +28,7 @@
     "dotenv": "^16.0.3",
     "nats": "^2.15.1",
     "rxjs": "^7.8.1",
-    "uuid": "^14.0.0"
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/crypto-js": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.31",
     "unzipper": "^0.12.3",
-    "uuid": "^14.0.0",
+    "uuid": "^9.0.1",
     "validator": "^13.15.35",
     "web-push": "^3.6.7",
     "winston": "^3.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,8 +369,8 @@ importers:
         specifier: ^0.12.3
         version: 0.12.3
       uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
+        specifier: ^9.0.1
+        version: 9.0.1
       validator:
         specifier: ^13.15.35
         version: 13.15.35
@@ -532,8 +532,8 @@ importers:
         specifier: ^7.8.1
         version: 7.8.2
       uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@types/crypto-js':
         specifier: ^4.1.1
@@ -6464,10 +6464,6 @@ packages:
 
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
-    hasBin: true
-
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uuid@3.4.0:
@@ -14161,8 +14157,6 @@ snapshots:
 
   uuid@11.1.1: {}
 
-  uuid@14.0.0: {}
-
   uuid@3.4.0:
     optional: true
 
@@ -14170,8 +14164,7 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  uuid@9.0.1:
-    optional: true
+  uuid@9.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
Reverts commit 85139dc6 (PR #1658).

**Problem:** uuid 14.0.0 is ESM-only. The repo's CommonJS jest runtime cannot load it (`SyntaxError: Unexpected token 'export'` at `uuid/dist-node/index.js:1`), which broke 8+ suites that import uuid transitively via `libs/common/src/NATSClient.ts`.

**Why revert rather than fix:** the bump carried no security fix (uuid 9.0.1 has no advisories) and was a version-hygiene bump. Runtime on Node 24 works via require(ESM), but dev tooling (jest, ts-node) and any future CI cannot load it without a proper ESM migration.

**Verification:** full jest run on this revert matches the pre-bump baseline exactly — 19 pre-existing broken suites, 5 failed tests, 56 passed. No new failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the UUID package version used by the application to improve compatibility and consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->