### PR TITLE
fix(cloud-wallet): harden holder isolation and agent routing

### DIFF
--- a/apps/api-gateway/src/cloud-wallet/cloud-wallet.controller.spec.ts
+++ b/apps/api-gateway/src/cloud-wallet/cloud-wallet.controller.spec.ts
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ForbiddenException } from '@nestjs/common';
+import { OrgRoles } from 'libs/org-roles/enums';
+import { OrgRolesGuard } from '../authz/guards/org-roles.guard';
+import { ROLES_KEY } from '../authz/decorators/roles.decorator';
+import { CloudWalletController } from './cloud-wallet.controller';
+
+describe('CloudWalletController base wallet authorization', () => {
+  it('marks base-wallet configuration as platform-admin-only', () => {
+    expect(Reflect.getMetadata(ROLES_KEY, CloudWalletController.prototype.configureBaseWallet)).toEqual([OrgRoles.PLATFORM_ADMIN]);
+  });
+
+  function contextFor(user: object): any {
+    return {
+      getHandler: () => CloudWalletController.prototype.configureBaseWallet,
+      getClass: () => CloudWalletController,
+      switchToHttp: () => ({
+        getRequest: () => ({ user, params: {}, query: {}, body: {} })
+      })
+    };
+  }
+
+  const reflector = {
+    getAllAndOverride: jest.fn().mockReturnValue([OrgRoles.PLATFORM_ADMIN])
+  };
+
+  it('rejects a non-administrator from configuring the base wallet', async () => {
+    const guard = new OrgRolesGuard(reflector as any);
+
+    await expect(guard.canActivate(contextFor({ userOrgRoles: [] }))).resolves.toBe(false);
+  });
+
+  it('allows a platform administrator to configure the base wallet', async () => {
+    const guard = new OrgRolesGuard(reflector as any);
+
+    await expect(
+      guard.canActivate(
+        contextFor({
+          userOrgRoles: [{ orgRole: { name: OrgRoles.PLATFORM_ADMIN } }]
+        })
+      )
+    ).resolves.toBe(true);
+  });
+
+  it('rejects a holder even if the holder has no organization selected', async () => {
+    const guard = new OrgRolesGuard(reflector as any);
+
+    await expect(guard.canActivate(contextFor({ userRole: ['holder'], userOrgRoles: [] }))).rejects.toBeInstanceOf(
+      ForbiddenException
+    );
+  });
+});

--- a/apps/api-gateway/src/cloud-wallet/cloud-wallet.controller.ts
+++ b/apps/api-gateway/src/cloud-wallet/cloud-wallet.controller.ts
@@ -46,6 +46,9 @@ import { user } from '@prisma/client';
 import { Validator } from '@credebl/common/validator';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { UserRoleGuard } from '../authz/guards/user-role.guard';
+import { OrgRolesGuard } from '../authz/guards/org-roles.guard';
+import { Roles } from '../authz/decorators/roles.decorator';
+import { OrgRoles } from 'libs/org-roles/enums';
 import { AcceptProofRequestDto } from './dtos/accept-proof-request.dto';
 import {
   IBasicMessage,
@@ -80,7 +83,8 @@ export class CloudWalletController {
     description: 'Endpoint to configure the base wallet for the cloud wallet service.'
   })
   @ApiResponse({ status: HttpStatus.CREATED, description: 'Base wallet configured successfully', type: ApiResponseDto })
-  @UseGuards(AuthGuard('jwt'))
+  @Roles(OrgRoles.PLATFORM_ADMIN)
+  @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
   async configureBaseWallet(
     @Res() res: Response,
     @Body() cloudBaseWalletConfigure: CloudBaseWalletConfigureDto,

--- a/apps/cloud-wallet/src/cloud-wallet.repository.spec.ts
+++ b/apps/cloud-wallet/src/cloud-wallet.repository.spec.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, camelcase */
+import { CloudWalletType } from '@credebl/enum/enum';
+import { CloudWalletRepository } from './cloud-wallet.repository';
+
+describe('CloudWalletRepository', () => {
+  it('queries a holder wallet by both authenticated user id and sub-wallet type', async () => {
+    const prisma = {
+      cloud_wallet_user_info: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'holder-wallet' })
+      }
+    };
+    const repository = new CloudWalletRepository(prisma as any, { error: jest.fn() } as any);
+
+    await expect(repository.getCloudSubWallet('holder-user')).resolves.toEqual({ id: 'holder-wallet' });
+
+    expect(prisma.cloud_wallet_user_info.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: 'holder-user',
+        type: CloudWalletType.SUB_WALLET
+      }
+    });
+  });
+});

--- a/apps/cloud-wallet/src/cloud-wallet.repository.ts
+++ b/apps/cloud-wallet/src/cloud-wallet.repository.ts
@@ -30,6 +30,20 @@ export class CloudWalletRepository {
   }
 
   // eslint-disable-next-line camelcase
+  async getCloudBaseWallet(): Promise<cloud_wallet_user_info> {
+    try {
+      return await this.prisma.cloud_wallet_user_info.findFirst({
+        where: {
+          type: CloudWalletType.BASE_WALLET
+        }
+      });
+    } catch (error) {
+      this.logger.error(`Error in getCloudBaseWallet: ${error}`);
+      throw error;
+    }
+  }
+
+  // eslint-disable-next-line camelcase
   async checkUserExist(email: string): Promise<cloud_wallet_user_info> {
     try {
       const agentDetails = await this.prisma.cloud_wallet_user_info.findUnique({
@@ -80,16 +94,16 @@ export class CloudWalletRepository {
   }
 
   // eslint-disable-next-line camelcase
-  async getCloudWalletInfo(email: string): Promise<cloud_wallet_user_info> {
+  async getCloudSubWallet(userId: string): Promise<cloud_wallet_user_info> {
     try {
-      const walletInfoData = await this.prisma.cloud_wallet_user_info.findUnique({
+      return await this.prisma.cloud_wallet_user_info.findFirst({
         where: {
-          email
+          userId,
+          type: CloudWalletType.SUB_WALLET
         }
       });
-      return walletInfoData;
     } catch (error) {
-      this.logger.error(`Error in getCloudWalletInfo: ${error}`);
+      this.logger.error(`Error in getCloudSubWallet: ${error}`);
       throw error;
     }
   }
@@ -119,21 +133,6 @@ export class CloudWalletRepository {
       return walletInfoData;
     } catch (error) {
       this.logger.error(`Error in storeCloudWalletInfo: ${error}`);
-      throw error;
-    }
-  }
-
-  // eslint-disable-next-line camelcase
-  async getCloudSubWallet(userId: string): Promise<cloud_wallet_user_info> {
-    try {
-      const cloudSubWalletDetails = await this.prisma.cloud_wallet_user_info.findFirstOrThrow({
-        where: {
-          userId
-        }
-      });
-      return cloudSubWalletDetails;
-    } catch (error) {
-      this.logger.error(`Error in getCloudSubWallet: ${error}`);
       throw error;
     }
   }

--- a/apps/cloud-wallet/src/cloud-wallet.service.spec.ts
+++ b/apps/cloud-wallet/src/cloud-wallet.service.spec.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-function-return-type */
+import { NotFoundException } from '@nestjs/common';
+import { CloudWalletType } from '@credebl/enum/enum';
+import { CloudWalletService } from './cloud-wallet.service';
+
+describe('CloudWalletService holder isolation', () => {
+  const baseWallet = {
+    agentEndpoint: 'https://wallet-agent.example',
+    type: CloudWalletType.BASE_WALLET
+  };
+  const holderWallet = {
+    tenantId: 'holder-tenant',
+    agentApiKey: 'encrypted-holder-token',
+    type: CloudWalletType.SUB_WALLET
+  };
+
+  function createService(getCloudSubWallet = jest.fn().mockResolvedValue(holderWallet)) {
+    const commonService = {
+      httpGet: jest.fn().mockResolvedValueOnce({ isInitialized: true }).mockResolvedValueOnce([]),
+      decryptPassword: jest.fn().mockResolvedValue('holder-token')
+    };
+    const repository = {
+      getCloudSubWallet,
+      getCloudWalletDetails: jest.fn().mockResolvedValue(baseWallet)
+    };
+    const service = new CloudWalletService(commonService as any, repository as any, { error: jest.fn() } as any);
+
+    return { commonService, repository, service };
+  }
+
+  it('uses the authenticated holder sub-wallet token for a normal holder operation', async () => {
+    const { commonService, repository, service } = createService();
+
+    await expect(service.getDidList({ userId: 'holder-user', email: 'holder@example.test' })).resolves.toEqual([]);
+
+    expect(repository.getCloudSubWallet).toHaveBeenCalledWith('holder-user');
+    expect(commonService.decryptPassword).toHaveBeenCalledWith('encrypted-holder-token');
+    expect(commonService.httpGet).toHaveBeenLastCalledWith('https://wallet-agent.example/dids', {
+      headers: { authorization: 'holder-token' }
+    });
+  });
+
+  it('rejects a cross-holder lookup before resolving a base wallet', async () => {
+    const { commonService, repository, service } = createService(jest.fn().mockResolvedValue(null));
+
+    await expect(service._commonCloudWalletInfo('other-holder')).rejects.toBeInstanceOf(NotFoundException);
+
+    expect(repository.getCloudSubWallet).toHaveBeenCalledWith('other-holder');
+    expect(repository.getCloudWalletDetails).not.toHaveBeenCalled();
+    expect(commonService.decryptPassword).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a base-wallet record as a holder wallet', async () => {
+    const { commonService, repository, service } = createService(jest.fn().mockResolvedValue(null));
+
+    await expect(service._commonCloudWalletInfo('base-wallet-owner')).rejects.toBeInstanceOf(NotFoundException);
+
+    expect(repository.getCloudWalletDetails).not.toHaveBeenCalled();
+    expect(commonService.decryptPassword).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cloud-wallet/src/cloud-wallet.service.spec.ts
+++ b/apps/cloud-wallet/src/cloud-wallet.service.spec.ts
@@ -16,8 +16,9 @@ describe('CloudWalletService holder isolation', () => {
 
   function createService(getCloudSubWallet = jest.fn().mockResolvedValue(holderWallet)) {
     const commonService = {
-      httpGet: jest.fn().mockResolvedValueOnce({ isInitialized: true }).mockResolvedValueOnce([]),
-      decryptPassword: jest.fn().mockResolvedValue('holder-token')
+      httpGet: jest.fn().mockResolvedValue([]),
+      decryptPassword: jest.fn().mockResolvedValue('holder-token'),
+      checkAgentHealth: jest.fn().mockResolvedValue(true)
     };
     const repository = {
       getCloudSubWallet,
@@ -35,6 +36,7 @@ describe('CloudWalletService holder isolation', () => {
 
     expect(repository.getCloudSubWallet).toHaveBeenCalledWith('holder-user');
     expect(commonService.decryptPassword).toHaveBeenCalledWith('encrypted-holder-token');
+    expect(commonService.checkAgentHealth).toHaveBeenCalledWith('https://wallet-agent.example', 'holder-token');
     expect(commonService.httpGet).toHaveBeenLastCalledWith('https://wallet-agent.example/dids', {
       headers: { authorization: 'holder-token' }
     });
@@ -57,5 +59,47 @@ describe('CloudWalletService holder isolation', () => {
 
     expect(repository.getCloudWalletDetails).not.toHaveBeenCalled();
     expect(commonService.decryptPassword).not.toHaveBeenCalled();
+  });
+
+  it('uses the exact proof record route without appending stray characters', async () => {
+    const { commonService, service } = createService();
+
+    await service.getProofById({
+      userId: 'holder-user',
+      email: 'holder@example.test',
+      proofRecordId: 'proof-record'
+    });
+
+    expect(commonService.httpGet).toHaveBeenLastCalledWith('https://wallet-agent.example/didcomm/proofs/proof-record', {
+      headers: { authorization: 'holder-token' }
+    });
+  });
+
+  it('gets all proofs from the collection route when no thread filter is supplied', async () => {
+    const { commonService, service } = createService();
+
+    await service.getProofPresentation({
+      userId: 'holder-user',
+      email: 'holder@example.test'
+    });
+
+    expect(commonService.httpGet).toHaveBeenLastCalledWith('https://wallet-agent.example/didcomm/proofs', {
+      headers: { authorization: 'holder-token' }
+    });
+  });
+
+  it('passes the proof thread filter as an encoded HTTP query parameter', async () => {
+    const { commonService, service } = createService();
+
+    await service.getProofPresentation({
+      userId: 'holder-user',
+      email: 'holder@example.test',
+      threadId: 'thread/with?reserved=characters'
+    });
+
+    expect(commonService.httpGet).toHaveBeenLastCalledWith('https://wallet-agent.example/didcomm/proofs', {
+      headers: { authorization: 'holder-token' },
+      params: { threadId: 'thread/with?reserved=characters' }
+    });
   });
 });

--- a/apps/cloud-wallet/src/cloud-wallet.service.ts
+++ b/apps/cloud-wallet/src/cloud-wallet.service.ts
@@ -55,7 +55,7 @@ export class CloudWalletService {
     const { agentEndpoint, apiKey, email, walletKey, userId } = configureBaseWalletPayload;
 
     try {
-      const existingWalletInfo = await this.cloudWalletRepository.getCloudWalletInfo(email);
+      const existingWalletInfo = await this.cloudWalletRepository.getCloudBaseWallet();
       if (existingWalletInfo) {
         throw new ConflictException(ResponseMessages.cloudWallet.error.agentAlreadyExist);
       }
@@ -185,6 +185,12 @@ export class CloudWalletService {
    * @returns cloud wallet info
    */
   async _commonCloudWalletInfo(userId: string): Promise<[CloudWallet, string]> {
+    const getTenant = await this.cloudWalletRepository.getCloudSubWallet(userId);
+
+    if (!getTenant || !getTenant?.tenantId) {
+      throw new NotFoundException(ResponseMessages.cloudWallet.error.walletRecordNotFound);
+    }
+
     const baseWalletDetails = await this.cloudWalletRepository.getCloudWalletDetails(CloudWalletType.BASE_WALLET);
 
     if (!baseWalletDetails) {
@@ -196,12 +202,6 @@ export class CloudWalletService {
     );
     if (!getAgentDetails?.isInitialized) {
       throw new BadRequestException(ResponseMessages.cloudWallet.error.notReachable);
-    }
-
-    const getTenant = await this.cloudWalletRepository.getCloudSubWallet(userId);
-
-    if (!getTenant || !getTenant?.tenantId) {
-      throw new NotFoundException(ResponseMessages.cloudWallet.error.walletRecordNotFound);
     }
 
     const decryptedApiKey = await this.commonService.decryptPassword(getTenant?.agentApiKey);
@@ -224,7 +224,7 @@ export class CloudWalletService {
         }
       };
 
-      const checkUserExist = await this.cloudWalletRepository.checkUserExist(email);
+      const checkUserExist = await this.cloudWalletRepository.getCloudSubWallet(userId);
 
       if (checkUserExist) {
         throw new ConflictException(ResponseMessages.cloudWallet.error.userExist);
@@ -295,11 +295,11 @@ export class CloudWalletService {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { email, userId, ...invitationDetails } = ReceiveInvitationDetails;
 
-      const checkUserExist = await this.cloudWalletRepository.checkUserExist(email);
-
-      if (!checkUserExist) {
+      const cloudSubWallet = await this.cloudWalletRepository.getCloudSubWallet(userId);
+      if (!cloudSubWallet) {
         throw new ConflictException(ResponseMessages.cloudWallet.error.walletNotExist);
       }
+
       const [baseWalletDetails, decryptedApiKey] = await this._commonCloudWalletInfo(userId);
 
       const { agentEndpoint } = baseWalletDetails;
@@ -338,11 +338,11 @@ export class CloudWalletService {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { email, userId, ...offerDetails } = acceptOfferDetails;
 
-      const checkUserExist = await this.cloudWalletRepository.checkUserExist(email);
-
-      if (!checkUserExist) {
+      const cloudSubWallet = await this.cloudWalletRepository.getCloudSubWallet(userId);
+      if (!cloudSubWallet) {
         throw new ConflictException(ResponseMessages.cloudWallet.error.walletNotExist);
       }
+
       const [baseWalletDetails, decryptedApiKey] = await this._commonCloudWalletInfo(userId);
       const { agentEndpoint } = baseWalletDetails;
 
@@ -381,11 +381,11 @@ export class CloudWalletService {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { email, userId, ...didDetails } = createDidDetails;
 
-      const checkUserExist = await this.cloudWalletRepository.checkUserExist(email);
-
-      if (!checkUserExist) {
+      const cloudSubWallet = await this.cloudWalletRepository.getCloudSubWallet(userId);
+      if (!cloudSubWallet) {
         throw new ConflictException(ResponseMessages.cloudWallet.error.walletNotExist);
       }
+
       const [baseWalletDetails, decryptedApiKey] = await this._commonCloudWalletInfo(userId);
       const { agentEndpoint } = baseWalletDetails;
 

--- a/apps/cloud-wallet/src/cloud-wallet.service.ts
+++ b/apps/cloud-wallet/src/cloud-wallet.service.ts
@@ -148,7 +148,7 @@ export class CloudWalletService {
       const { proofRecordId, userId } = proofPrsentationByIdPayload;
       const [baseWalletDetails, decryptedApiKey] = await this._commonCloudWalletInfo(userId);
       const { agentEndpoint } = baseWalletDetails;
-      const url = `${agentEndpoint}${CommonConstants.CLOUD_WALLET_GET_PROOF_REQUEST}/${proofRecordId}}`;
+      const url = `${agentEndpoint}${CommonConstants.CLOUD_WALLET_GET_PROOF_REQUEST}/${proofRecordId}`;
 
       const getProofById = await this.commonService.httpGet(url, { headers: { authorization: decryptedApiKey } });
       return getProofById;
@@ -169,9 +169,11 @@ export class CloudWalletService {
 
       const [baseWalletDetails, decryptedApiKey] = await this._commonCloudWalletInfo(userId);
       const { agentEndpoint } = baseWalletDetails;
-      const threadParam = threadId ? `?threadId=${threadId}` : '';
-      const url = `${agentEndpoint}${CommonConstants.CLOUD_WALLET_GET_PROOF_REQUEST}/${threadParam}}`;
-      const getProofById = await this.commonService.httpGet(url, { headers: { authorization: decryptedApiKey } });
+      const url = `${agentEndpoint}${CommonConstants.CLOUD_WALLET_GET_PROOF_REQUEST}`;
+      const getProofById = await this.commonService.httpGet(url, {
+        headers: { authorization: decryptedApiKey },
+        ...(threadId ? { params: { threadId } } : {})
+      });
       return getProofById;
     } catch (error) {
       await this.commonService.handleError(error);
@@ -197,14 +199,11 @@ export class CloudWalletService {
       throw new NotFoundException(ResponseMessages.cloudWallet.error.notFoundBaseWallet);
     }
 
-    const getAgentDetails = await this.commonService.httpGet(
-      `${baseWalletDetails?.agentEndpoint}${CommonConstants.URL_AGENT_GET_ENDPOINT}`
-    );
-    if (!getAgentDetails?.isInitialized) {
+    const decryptedApiKey = await this.commonService.decryptPassword(getTenant.agentApiKey);
+    const isAgentHealthy = await this.commonService.checkAgentHealth(baseWalletDetails.agentEndpoint, decryptedApiKey);
+    if (!isAgentHealthy) {
       throw new BadRequestException(ResponseMessages.cloudWallet.error.notReachable);
     }
-
-    const decryptedApiKey = await this.commonService.decryptPassword(getTenant?.agentApiKey);
 
     return [baseWalletDetails, decryptedApiKey];
   }

--- a/libs/common/src/interfaces/cloud-wallet.interface.ts
+++ b/libs/common/src/interfaces/cloud-wallet.interface.ts
@@ -141,7 +141,7 @@ export interface IGetProofPresentationById {
 export interface IGetProofPresentation {
   userId: string;
   email: string;
-  threadId: string;
+  threadId?: string;
 }
 
 export interface ICloudBaseWalletConfigure {


### PR DESCRIPTION
Closes #1726

## Summary

- Scope Holder Cloud Wallet resolution to the authenticated user and CLOUD_SUB_WALLET records.
- Reject unresolved Holders before reading Base Wallet or tenant credentials.
- Restrict Base Wallet configuration to platform administrators.
- Authenticate Agent health checks with the resolved Holder tenant token.
- Correct Holder Proof record and collection routes and pass threadId as an HTTP query parameter.
- Preserve existing Holder-facing API request and response shapes.

## Validation

- Targeted Cloud Wallet and authorization Jest tests: 3 suites, 11 tests passed.
- Targeted ESLint.
- cloud-wallet and api-gateway builds.

## Out of scope

- Agent Controller JWT format, expiry, rotation, or revocation.
- Issuer Cloud Wallet architecture.
- KMS or envelope encryption.
- Database singleton enforcement for the Base Wallet.